### PR TITLE
ci: add GitHub Actions workflow for pre-commit checks and unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,9 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -495,7 +495,10 @@ mod tests {
             let seed = temp.path().join("seed");
             fs::create_dir_all(&seed).context("failed to create seed dir")?;
 
-            run_git_in(&temp.path().to_path_buf(), ["init", "--bare", "origin.git"])?;
+            run_git_in(
+                &temp.path().to_path_buf(),
+                ["init", "--bare", "-b", "main", "origin.git"],
+            )?;
 
             let seed_path = seed.to_string_lossy().to_string();
             run_git_in(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -121,7 +121,13 @@ impl GitFixture {
         std::fs::create_dir_all(&seed)?;
         run_git(
             temp.path(),
-            ["init", "--bare", origin.to_string_lossy().as_ref()],
+            [
+                "init",
+                "--bare",
+                "-b",
+                "main",
+                origin.to_string_lossy().as_ref(),
+            ],
         )?;
 
         run_git(


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yaml` with two parallel jobs:
  - **Test**: runs `cargo test --lib` for unit tests
  - **Lint**: runs `cargo check`, `cargo fmt`, and `cargo clippy`
- Triggers on push to `main/master` and feature branches (`feat-*`/`fix-*`), plus PRs to main