### PR TITLE
refactor: persist opencode session bindings for task sync

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1399,7 +1399,10 @@ fn attach_task_with_runtime(
         runtime,
     );
 
-    let command = opencode_attach_command(None, task.worktree_path.as_deref());
+    let command = opencode_attach_command(
+        task.opencode_session_id.as_deref(),
+        task.worktree_path.as_deref(),
+    );
 
     runtime.create_session(&session_name, worktree_path, &command)?;
     db.update_task_tmux(

--- a/src/opencode/mod.rs
+++ b/src/opencode/mod.rs
@@ -190,13 +190,13 @@ fn ensure_opencode_available(binary: &str) -> Result<()> {
 }
 
 pub fn opencode_attach_command(session_id: Option<&str>, worktree_dir: Option<&str>) -> String {
-    let url = DEFAULT_SERVER_URL;
     let dir_arg = worktree_dir
         .map(|d| format!(" --dir {}", d))
         .unwrap_or_default();
+
     match session_id {
-        Some(id) => format!("opencode attach {url} --session {id}{dir_arg}"),
-        None => format!("opencode attach {url}{dir_arg}"),
+        Some(id) => format!("opencode --session {id}{dir_arg}"),
+        None => format!("opencode{dir_arg}"),
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,7 @@ pub struct Task {
     pub status_source: String,
     pub status_fetched_at: Option<String>,
     pub status_error: Option<String>,
+    pub opencode_session_id: Option<String>,
     pub session_todo_json: Option<String>,
     pub created_at: String,
     pub updated_at: String,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -449,7 +449,7 @@ fn binding_state_from_task(task: &Task) -> OpenCodeBindingState {
         }),
     };
 
-    classify_binding_state(None, Some(&status))
+    classify_binding_state(task.opencode_session_id.as_deref(), Some(&status))
 }
 
 fn http_json_response(body: &str) -> String {


### PR DESCRIPTION
## Summary
- Persist a task-level `opencode_session_id` in SQLite and use it as the single source of truth for session-bound task utilities.
- Keep root-session status detection in the poller, but write detected root session IDs back to SQLite and use the persisted binding for todo sync.
- Update tmux OpenCode launch command construction to resume with `opencode --session <id>` when a previous binding exists.

## Validation
- `cargo test --lib`
- `cargo build`
- `cargo clippy -- -D warnings`
- `cargo test --test integration integration_test_full_lifecycle`