### PR TITLE
feat: add color-coded checklist todo visualization

### DIFF
--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -47,6 +47,7 @@ pub enum Message {
     CancelQuit,
     ExecuteCommand(String),
     CycleCategoryColor(usize),
+    CycleTodoVisualization,
     SwitchToProjectList,
     SwitchToBoard(PathBuf),
     ProjectListSelectUp,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,5 +1,7 @@
 //! Application state types for dialogs and UI components
 
+use std::str::FromStr;
+
 use uuid::Uuid;
 
 use crate::command_palette::CommandPaletteState;
@@ -163,6 +165,40 @@ pub enum ViewMode {
     SidePanel,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum TodoVisualizationMode {
+    Summary,
+    Checklist,
+}
+
+impl TodoVisualizationMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TodoVisualizationMode::Summary => "summary",
+            TodoVisualizationMode::Checklist => "checklist",
+        }
+    }
+
+    pub fn cycle(self) -> Self {
+        match self {
+            TodoVisualizationMode::Summary => TodoVisualizationMode::Checklist,
+            TodoVisualizationMode::Checklist => TodoVisualizationMode::Summary,
+        }
+    }
+}
+
+impl FromStr for TodoVisualizationMode {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "summary" => Ok(Self::Summary),
+            "checklist" | "plan" => Ok(Self::Checklist),
+            _ => Err(()),
+        }
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ActiveDialog {
@@ -204,4 +240,38 @@ pub enum AttachTaskResult {
 #[derive(Debug, Clone)]
 pub struct CreateTaskOutcome {
     pub warning: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TodoVisualizationMode;
+    use std::str::FromStr;
+
+    #[test]
+    fn todo_visualization_mode_cycles_between_values() {
+        assert_eq!(
+            TodoVisualizationMode::Summary.cycle(),
+            TodoVisualizationMode::Checklist
+        );
+        assert_eq!(
+            TodoVisualizationMode::Checklist.cycle(),
+            TodoVisualizationMode::Summary
+        );
+    }
+
+    #[test]
+    fn todo_visualization_mode_parses_supported_values() {
+        assert_eq!(
+            TodoVisualizationMode::from_str("summary"),
+            Ok(TodoVisualizationMode::Summary)
+        );
+        assert_eq!(
+            TodoVisualizationMode::from_str("checklist"),
+            Ok(TodoVisualizationMode::Checklist)
+        );
+        assert_eq!(
+            TodoVisualizationMode::from_str("plan"),
+            Ok(TodoVisualizationMode::Checklist)
+        );
+    }
 }

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -169,6 +169,12 @@ pub fn all_commands() -> Vec<CommandDef> {
             message: Some(Message::AttachSelectedTask),
         },
         CommandDef {
+            id: "cycle_todo_visualization",
+            display_name: "Cycle Todo Visualization",
+            keybinding: "t",
+            message: Some(Message::CycleTodoVisualization),
+        },
+        CommandDef {
             id: "add_category",
             display_name: "Add Category",
             keybinding: "c",
@@ -302,8 +308,8 @@ mod tests {
         let commands = all_commands();
         assert_eq!(
             commands.len(),
-            17,
-            "Expected 17 commands, found {}",
+            18,
+            "Expected 18 commands, found {}",
             commands.len()
         );
     }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -41,6 +41,7 @@ pub enum KeyAction {
     MoveTaskDown,
     MoveTaskUp,
     AttachTask,
+    CycleTodoVisualization,
     Dismiss,
 }
 
@@ -295,6 +296,12 @@ const BOARD_DEFS: &[ActionDef] = &[
         defaults: &["Enter"],
     },
     ActionDef {
+        id: "cycle_todo_visualization",
+        action: KeyAction::CycleTodoVisualization,
+        description: "cycle todo visualization",
+        defaults: &["t"],
+    },
+    ActionDef {
         id: "dismiss",
         action: KeyAction::Dismiss,
         description: "dismiss",
@@ -348,6 +355,9 @@ impl Keybindings {
             "navigate_right" => self.display_for(KeyContext::Board, KeyAction::NavigateRight),
             "select_up" => self.display_for(KeyContext::Board, KeyAction::SelectUp),
             "select_down" => self.display_for(KeyContext::Board, KeyAction::SelectDown),
+            "cycle_todo_visualization" => {
+                self.display_for(KeyContext::Board, KeyAction::CycleTodoVisualization)
+            }
             "help" => self.display_for(KeyContext::Global, KeyAction::ToggleHelp),
             "quit" => self.display_for(KeyContext::Global, KeyAction::Quit),
             _ => None,
@@ -416,6 +426,11 @@ impl Keybindings {
             format!(
                 "  {}: attach selected task",
                 self.display_for(KeyContext::Board, KeyAction::AttachTask)
+                    .unwrap_or_else(|| "-".to_string())
+            ),
+            format!(
+                "  {}: cycle todo visualization",
+                self.display_for(KeyContext::Board, KeyAction::CycleTodoVisualization)
                     .unwrap_or_else(|| "-".to_string())
             ),
             format!(
@@ -704,5 +719,15 @@ mod tests {
             KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()),
         );
         assert_eq!(action, Some(KeyAction::Quit));
+    }
+
+    #[test]
+    fn defaults_include_cycle_todo_visualization() {
+        let keys = Keybindings::load();
+        let action = keys.action_for_key(
+            KeyContext::Board,
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::empty()),
+        );
+        assert_eq!(action, Some(KeyAction::CycleTodoVisualization));
     }
 }


### PR DESCRIPTION
## Summary
- add a todo visualization mode with checklist as default plus runtime toggle support via `t`, command palette, and environment override
- render side-panel work plans as checklist lines using `┃ [✓]`, `┃ [•]`, and `┃ [ ]` markers with distinct colors for completed, active, and pending items
- expand tests for visualization mode parsing/cycling, keybinding defaults, command count, and checklist marker rendering