### PR TITLE
feat: add category color controls in settings

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -140,6 +140,7 @@ pub enum View {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum SettingsSection {
     Theme,
+    CategoryColors,
     Keybindings,
     General,
 }
@@ -148,6 +149,7 @@ pub enum SettingsSection {
 pub struct SettingsViewState {
     pub active_section: SettingsSection,
     pub general_selected_field: usize,
+    pub category_color_selected: usize,
     pub previous_view: View,
 }
 


### PR DESCRIPTION
## Summary
- add a new **Category Colors** settings section to select a category and cycle its color with `Enter`/`Space`
- wire settings navigation and toggle handling to persist color updates through existing `update_category_color` + refresh flow
- update board/footer help text and add tests covering settings color selection and toggle behavior

## Testing
- cargo test
- cargo build --release