### PR TITLE
feat: add project view UI improvements

### DIFF
--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -4,7 +4,10 @@ use std::path::PathBuf;
 
 use crossterm::event::{KeyEvent, MouseEvent};
 
-use super::state::{CategoryInputField, DeleteTaskField, NewProjectField, NewTaskField};
+use super::state::{
+    CategoryInputField, DeleteTaskField, NewProjectField, NewTaskField, RenameProjectField,
+    RenameRepoField,
+};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Message {
@@ -64,6 +67,16 @@ pub enum Message {
     ProjectListConfirm,
     OpenNewProjectDialog,
     CreateProject,
+    OpenRenameProjectDialog,
+    ConfirmRenameProject,
+    FocusRenameProjectField(RenameProjectField),
+    OpenDeleteProjectDialog,
+    ConfirmDeleteProject,
+    OpenRenameRepoDialog,
+    ConfirmRenameRepo,
+    FocusRenameRepoField(RenameRepoField),
+    OpenDeleteRepoDialog,
+    ConfirmDeleteRepo,
     FocusNewTaskField(NewTaskField),
     ToggleNewTaskCheckbox,
     FocusCategoryInputField(CategoryInputField),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -26,10 +26,12 @@ pub use self::state::{
     ActiveDialog, CATEGORY_COLOR_PALETTE, CategoryColorDialogState, CategoryColorField,
     CategoryInputDialogState, CategoryInputField, CategoryInputMode, ConfirmQuitDialogState,
     ContextMenuItem, ContextMenuState, DeleteCategoryDialogState, DeleteCategoryField,
-    DeleteTaskDialogState, DeleteTaskField, ErrorDialogState, MoveTaskDialogState,
-    NewProjectDialogState, NewProjectField, NewTaskDialogState, NewTaskField,
-    RepoUnavailableDialogState, SettingsSection, SettingsViewState, TodoVisualizationMode, View,
-    ViewMode, WorktreeNotFoundDialogState, WorktreeNotFoundField, category_color_label,
+    DeleteProjectDialogState, DeleteRepoDialogState, DeleteTaskDialogState, DeleteTaskField,
+    ErrorDialogState, MoveTaskDialogState, NewProjectDialogState, NewProjectField,
+    NewTaskDialogState, NewTaskField, RenameProjectDialogState, RenameProjectField,
+    RenameRepoDialogState, RenameRepoField, RepoUnavailableDialogState, SettingsSection,
+    SettingsViewState, TodoVisualizationMode, View, ViewMode, WorktreeNotFoundDialogState,
+    WorktreeNotFoundField, category_color_label,
 };
 
 use crate::command_palette::{CommandPaletteState, all_commands};
@@ -67,6 +69,15 @@ pub enum SidePanelRow {
         category_id: Uuid,
         task: Box<Task>,
     },
+}
+
+pub struct ProjectDetailCache {
+    pub project_name: String,
+    pub task_count: usize,
+    pub running_count: usize,
+    pub repo_count: usize,
+    pub category_count: usize,
+    pub file_size_kb: u64,
 }
 
 pub struct App {
@@ -111,6 +122,27 @@ pub struct App {
     pub settings: crate::settings::Settings,
     pub settings_view_state: Option<SettingsViewState>,
     pub category_edit_mode: bool,
+    pub project_detail_cache: Option<ProjectDetailCache>,
+}
+
+fn load_project_detail(info: &crate::projects::ProjectInfo) -> Option<ProjectDetailCache> {
+    let db = Database::open(&info.path).ok()?;
+    let tasks = db.list_tasks().ok()?;
+    let repos = db.list_repos().ok()?;
+    let categories = db.list_categories().ok()?;
+    let running = tasks.iter().filter(|t| t.tmux_status == "running").count();
+    let size_kb = fs::metadata(&info.path)
+        .ok()
+        .map(|m| m.len() / 1024)
+        .unwrap_or(0);
+    Some(ProjectDetailCache {
+        project_name: info.name.clone(),
+        task_count: tasks.len(),
+        running_count: running,
+        repo_count: repos.len(),
+        category_count: categories.len(),
+        file_size_kb: size_kb,
+    })
 }
 
 impl App {
@@ -191,6 +223,7 @@ impl App {
             settings,
             settings_view_state: None,
             category_edit_mode: false,
+            project_detail_cache: None,
         };
 
         app.refresh_data()?;
@@ -329,9 +362,13 @@ impl App {
                 self.selected_project_index.min(self.project_list.len() - 1);
             self.project_list_state
                 .select(Some(self.selected_project_index));
+            if let Some(project) = self.project_list.get(self.selected_project_index) {
+                self.project_detail_cache = load_project_detail(project);
+            }
         } else {
             self.selected_project_index = 0;
             self.project_list_state.select(None);
+            self.project_detail_cache = None;
         }
         Ok(())
     }
@@ -473,6 +510,7 @@ impl App {
                     category_color_selected: self
                         .focused_column
                         .min(self.categories.len().saturating_sub(1)),
+                    repos_selected_field: 0,
                     previous_view: self.current_view,
                 });
                 self.current_view = View::Settings;
@@ -493,17 +531,19 @@ impl App {
                         SettingsSection::Theme => SettingsSection::CategoryColors,
                         SettingsSection::CategoryColors => SettingsSection::Keybindings,
                         SettingsSection::Keybindings => SettingsSection::General,
-                        SettingsSection::General => SettingsSection::Theme,
+                        SettingsSection::General => SettingsSection::Repos,
+                        SettingsSection::Repos => SettingsSection::Theme,
                     };
                 }
             }
             Message::SettingsPrevSection => {
                 if let Some(state) = &mut self.settings_view_state {
                     state.active_section = match state.active_section {
-                        SettingsSection::Theme => SettingsSection::General,
+                        SettingsSection::Theme => SettingsSection::Repos,
                         SettingsSection::CategoryColors => SettingsSection::Theme,
                         SettingsSection::Keybindings => SettingsSection::CategoryColors,
                         SettingsSection::General => SettingsSection::Keybindings,
+                        SettingsSection::Repos => SettingsSection::General,
                     };
                 }
             }
@@ -520,6 +560,12 @@ impl App {
                                 .saturating_add(1)
                                 .min(self.categories.len().saturating_sub(1));
                         }
+                        SettingsSection::Repos => {
+                            state.repos_selected_field = state
+                                .repos_selected_field
+                                .saturating_add(1)
+                                .min(self.repos.len().saturating_sub(1));
+                        }
                         SettingsSection::Theme | SettingsSection::Keybindings => {}
                     }
                 }
@@ -534,6 +580,10 @@ impl App {
                         SettingsSection::CategoryColors => {
                             state.category_color_selected =
                                 state.category_color_selected.saturating_sub(1);
+                        }
+                        SettingsSection::Repos => {
+                            state.repos_selected_field =
+                                state.repos_selected_field.saturating_sub(1);
                         }
                         SettingsSection::Theme | SettingsSection::Keybindings => {}
                     }
@@ -611,6 +661,7 @@ impl App {
                             }
                         }
                         SettingsSection::Keybindings => {}
+                        SettingsSection::Repos => {}
                     }
                 }
             }
@@ -715,6 +766,9 @@ impl App {
                     self.selected_project_index -= 1;
                     self.project_list_state
                         .select(Some(self.selected_project_index));
+                    if let Some(project) = self.project_list.get(self.selected_project_index) {
+                        self.project_detail_cache = load_project_detail(project);
+                    }
                 }
             }
             Message::ProjectListSelectDown => {
@@ -722,6 +776,9 @@ impl App {
                     self.selected_project_index += 1;
                     self.project_list_state
                         .select(Some(self.selected_project_index));
+                    if let Some(project) = self.project_list.get(self.selected_project_index) {
+                        self.project_detail_cache = load_project_detail(project);
+                    }
                 }
             }
             Message::ProjectListConfirm => {
@@ -761,6 +818,152 @@ impl App {
                                     detail: e.to_string(),
                                 });
                             }
+                        }
+                    }
+                }
+            }
+            Message::OpenRenameProjectDialog => {
+                if let Some(project) = self.project_list.get(self.selected_project_index) {
+                    self.active_dialog = ActiveDialog::RenameProject(RenameProjectDialogState {
+                        name_input: project.name.clone(),
+                        focused_field: RenameProjectField::Name,
+                    });
+                }
+            }
+            Message::ConfirmRenameProject => {
+                if let ActiveDialog::RenameProject(state) = &self.active_dialog {
+                    let new_name = state.name_input.trim().to_string();
+                    if !new_name.is_empty()
+                        && let Some(project) = self.project_list.get(self.selected_project_index)
+                    {
+                        let old_path = project.path.clone();
+                        let is_current = self.current_project_path.as_deref() == Some(&old_path);
+                        match projects::rename_project(&old_path, &new_name) {
+                            Ok(new_path) => {
+                                self.active_dialog = ActiveDialog::None;
+                                if is_current {
+                                    self.current_project_path = Some(new_path.clone());
+                                }
+                                self.refresh_projects()?;
+                            }
+                            Err(e) => {
+                                self.active_dialog = ActiveDialog::Error(ErrorDialogState {
+                                    title: "Failed to rename project".to_string(),
+                                    detail: e.to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            Message::FocusRenameProjectField(field) => {
+                if let ActiveDialog::RenameProject(state) = &mut self.active_dialog {
+                    state.focused_field = field;
+                }
+            }
+            Message::OpenDeleteProjectDialog => {
+                if let Some(project) = self.project_list.get(self.selected_project_index) {
+                    self.active_dialog = ActiveDialog::DeleteProject(DeleteProjectDialogState {
+                        project_name: project.name.clone(),
+                        project_path: project.path.clone(),
+                    });
+                }
+            }
+            Message::ConfirmDeleteProject => {
+                if let ActiveDialog::DeleteProject(state) = &self.active_dialog {
+                    let path = state.project_path.clone();
+                    let is_current = self.current_project_path.as_deref() == Some(&path);
+                    if is_current {
+                        self.active_dialog = ActiveDialog::Error(ErrorDialogState {
+                            title: "Cannot delete active project".to_string(),
+                            detail: "Switch to another project first.".to_string(),
+                        });
+                    } else {
+                        match projects::delete_project(&path) {
+                            Ok(()) => {
+                                self.active_dialog = ActiveDialog::None;
+                                self.selected_project_index =
+                                    self.selected_project_index.saturating_sub(1);
+                                self.refresh_projects()?;
+                            }
+                            Err(e) => {
+                                self.active_dialog = ActiveDialog::Error(ErrorDialogState {
+                                    title: "Failed to delete project".to_string(),
+                                    detail: e.to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            Message::OpenRenameRepoDialog => {
+                let repos_selected = self
+                    .settings_view_state
+                    .as_ref()
+                    .map(|s| s.repos_selected_field)
+                    .unwrap_or(0);
+                if let Some(repo) = self.repos.get(repos_selected) {
+                    self.active_dialog = ActiveDialog::RenameRepo(RenameRepoDialogState {
+                        repo_id: repo.id,
+                        name_input: repo.name.clone(),
+                        focused_field: RenameRepoField::Name,
+                    });
+                }
+            }
+            Message::ConfirmRenameRepo => {
+                if let ActiveDialog::RenameRepo(state) = &self.active_dialog {
+                    let new_name = state.name_input.trim().to_string();
+                    let repo_id = state.repo_id;
+                    if !new_name.is_empty() {
+                        match self.db.update_repo_name(repo_id, &new_name) {
+                            Ok(()) => {
+                                self.active_dialog = ActiveDialog::None;
+                                self.refresh_data()?;
+                            }
+                            Err(e) => {
+                                self.active_dialog = ActiveDialog::Error(ErrorDialogState {
+                                    title: "Failed to rename repo".to_string(),
+                                    detail: e.to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            Message::FocusRenameRepoField(field) => {
+                if let ActiveDialog::RenameRepo(state) = &mut self.active_dialog {
+                    state.focused_field = field;
+                }
+            }
+            Message::OpenDeleteRepoDialog => {
+                let repos_selected = self
+                    .settings_view_state
+                    .as_ref()
+                    .map(|s| s.repos_selected_field)
+                    .unwrap_or(0);
+                if let Some(repo) = self.repos.get(repos_selected) {
+                    self.active_dialog = ActiveDialog::DeleteRepo(DeleteRepoDialogState {
+                        repo_id: repo.id,
+                        repo_name: repo.name.clone(),
+                    });
+                }
+            }
+            Message::ConfirmDeleteRepo => {
+                if let ActiveDialog::DeleteRepo(state) = &self.active_dialog {
+                    let repo_id = state.repo_id;
+                    match self.db.delete_repo(repo_id) {
+                        Ok(()) => {
+                            self.active_dialog = ActiveDialog::None;
+                            self.refresh_data()?;
+                            if let Some(s) = &mut self.settings_view_state {
+                                s.repos_selected_field = s.repos_selected_field.saturating_sub(1);
+                            }
+                        }
+                        Err(e) => {
+                            self.active_dialog = ActiveDialog::Error(ErrorDialogState {
+                                title: "Failed to delete repo".to_string(),
+                                detail: e.to_string(),
+                            });
                         }
                     }
                 }
@@ -913,6 +1116,8 @@ impl App {
                     KeyAction::ProjectDown => self.update(Message::ProjectListSelectDown)?,
                     KeyAction::ProjectConfirm => self.update(Message::ProjectListConfirm)?,
                     KeyAction::NewProject => self.update(Message::OpenNewProjectDialog)?,
+                    KeyAction::ProjectRename => self.update(Message::OpenRenameProjectDialog)?,
+                    KeyAction::ProjectDelete => self.update(Message::OpenDeleteProjectDialog)?,
                     _ => {}
                 }
             }
@@ -920,12 +1125,19 @@ impl App {
         }
 
         if self.current_view == View::Settings {
+            let active_section = self.settings_view_state.as_ref().map(|s| s.active_section);
             match key.code {
                 KeyCode::Left | KeyCode::Char('h') => self.update(Message::SettingsPrevSection)?,
                 KeyCode::Right | KeyCode::Char('l') => self.update(Message::SettingsNextSection)?,
                 KeyCode::Up | KeyCode::Char('k') => self.update(Message::SettingsPrevItem)?,
                 KeyCode::Down | KeyCode::Char('j') => self.update(Message::SettingsNextItem)?,
                 KeyCode::Enter | KeyCode::Char(' ') => self.update(Message::SettingsToggle)?,
+                KeyCode::Char('r') if active_section == Some(SettingsSection::Repos) => {
+                    self.update(Message::OpenRenameRepoDialog)?;
+                }
+                KeyCode::Char('x') if active_section == Some(SettingsSection::Repos) => {
+                    self.update(Message::OpenDeleteRepoDialog)?;
+                }
                 KeyCode::Esc => self.update(Message::CloseSettings)?,
                 _ => {}
             }
@@ -2167,6 +2379,7 @@ mod tests {
             settings: crate::settings::Settings::load(),
             settings_view_state: None,
             category_edit_mode: false,
+            project_detail_cache: None,
         };
 
         app.refresh_data()?;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,5 +1,6 @@
 //! Application state types for dialogs and UI components
 
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use uuid::Uuid;
@@ -41,6 +42,45 @@ pub struct NewProjectDialogState {
     pub name_input: String,
     pub focused_field: NewProjectField,
     pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RenameProjectField {
+    Name,
+    Confirm,
+    Cancel,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RenameProjectDialogState {
+    pub name_input: String,
+    pub focused_field: RenameProjectField,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DeleteProjectDialogState {
+    pub project_name: String,
+    pub project_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RenameRepoField {
+    Name,
+    Confirm,
+    Cancel,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RenameRepoDialogState {
+    pub repo_id: Uuid,
+    pub name_input: String,
+    pub focused_field: RenameRepoField,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DeleteRepoDialogState {
+    pub repo_id: Uuid,
+    pub repo_name: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -143,6 +183,7 @@ pub enum SettingsSection {
     CategoryColors,
     Keybindings,
     General,
+    Repos,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -150,6 +191,7 @@ pub struct SettingsViewState {
     pub active_section: SettingsSection,
     pub general_selected_field: usize,
     pub category_color_selected: usize,
+    pub repos_selected_field: usize,
     pub previous_view: View,
 }
 
@@ -258,6 +300,8 @@ pub enum ActiveDialog {
     NewTask(NewTaskDialogState),
     CommandPalette(CommandPaletteState),
     NewProject(NewProjectDialogState),
+    RenameProject(RenameProjectDialogState),
+    DeleteProject(DeleteProjectDialogState),
     CategoryInput(CategoryInputDialogState),
     CategoryColor(CategoryColorDialogState),
     DeleteCategory(DeleteCategoryDialogState),
@@ -267,6 +311,8 @@ pub enum ActiveDialog {
     WorktreeNotFound(WorktreeNotFoundDialogState),
     RepoUnavailable(RepoUnavailableDialogState),
     ConfirmQuit(ConfirmQuitDialogState),
+    RenameRepo(RenameRepoDialogState),
+    DeleteRepo(DeleteRepoDialogState),
     Help,
 }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -26,6 +26,8 @@ pub enum KeyAction {
     ProjectDown,
     ProjectConfirm,
     NewProject,
+    ProjectRename,
+    ProjectDelete,
     NavigateLeft,
     NavigateRight,
     SelectDown,
@@ -208,6 +210,18 @@ const PROJECT_LIST_DEFS: &[ActionDef] = &[
         action: KeyAction::NewProject,
         description: "new project",
         defaults: &["n"],
+    },
+    ActionDef {
+        id: "rename_project",
+        action: KeyAction::ProjectRename,
+        description: "rename selected project",
+        defaults: &["r"],
+    },
+    ActionDef {
+        id: "delete_project",
+        action: KeyAction::ProjectDelete,
+        description: "delete selected project",
+        defaults: &["x"],
     },
 ];
 
@@ -412,6 +426,21 @@ impl Keybindings {
             format!(
                 "  {}: open project",
                 self.display_for(KeyContext::ProjectList, KeyAction::ProjectConfirm)
+                    .unwrap_or_else(|| "-".to_string())
+            ),
+            format!(
+                "  {}: new project",
+                self.display_for(KeyContext::ProjectList, KeyAction::NewProject)
+                    .unwrap_or_else(|| "-".to_string())
+            ),
+            format!(
+                "  {}: rename project",
+                self.display_for(KeyContext::ProjectList, KeyAction::ProjectRename)
+                    .unwrap_or_else(|| "-".to_string())
+            ),
+            format!(
+                "  {}: delete project",
+                self.display_for(KeyContext::ProjectList, KeyAction::ProjectDelete)
                     .unwrap_or_else(|| "-".to_string())
             ),
             String::new(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,8 +15,10 @@ use tuirealm::{
 
 use crate::app::{
     ActiveDialog, App, CATEGORY_COLOR_PALETTE, CategoryColorField, CategoryInputField,
-    CategoryInputMode, DeleteCategoryField, DeleteTaskField, NewTaskField, SettingsSection,
-    SidePanelRow, TodoVisualizationMode, View, ViewMode, category_color_label,
+    CategoryInputMode, DeleteCategoryField, DeleteProjectDialogState, DeleteRepoDialogState,
+    DeleteTaskField, NewProjectDialogState, NewProjectField, NewTaskField, ProjectDetailCache,
+    RenameProjectDialogState, RenameProjectField, RenameRepoDialogState, RenameRepoField,
+    SettingsSection, SidePanelRow, TodoVisualizationMode, View, ViewMode, category_color_label,
 };
 use crate::command_palette::all_commands;
 use crate::theme::Theme;
@@ -54,50 +56,131 @@ fn render_project_list(frame: &mut Frame<'_>, app: &App) {
         .split(frame.area());
 
     let mut header = Label::default()
-        .text("Select Project")
+        .text("opencode-kanban — Select Project")
         .alignment(Alignment::Center)
         .foreground(theme.base.header)
         .background(theme.base.canvas);
     header.view(frame, chunks[0]);
 
+    let content = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(chunks[1]);
+
     let mut rows = TableBuilder::default();
     for (idx, project) in app.project_list.iter().enumerate() {
-        let prefix = if idx == app.selected_project_index {
-            ">"
+        let is_selected = idx == app.selected_project_index;
+        let is_active = app
+            .current_project_path
+            .as_ref()
+            .map(|p| p == &project.path)
+            .unwrap_or(false);
+        let marker = if is_active { "*" } else { " " };
+        let name = format!("{} {}", marker, project.name);
+        if is_selected {
+            rows.add_col(TextSpan::new(name).fg(theme.interactive.focus).bold())
+                .add_row();
         } else {
-            " "
-        };
-        rows.add_col(TextSpan::from(prefix))
-            .add_col(TextSpan::from(project.name.clone()))
-            .add_row();
+            rows.add_col(TextSpan::from(name)).add_row();
+        }
     }
     if app.project_list.is_empty() {
-        rows.add_col(TextSpan::from(" "))
-            .add_col(TextSpan::from("No projects found"))
-            .add_row();
+        rows.add_col(TextSpan::from(
+            "  No projects found — press n to create one",
+        ))
+        .add_row();
     }
 
     let selected = app
         .selected_project_index
         .min(app.project_list.len().saturating_sub(1));
     let mut list = List::default()
-        .title("Projects", Alignment::Left)
+        .title("Projects  (* = active)", Alignment::Left)
         .borders(rounded_borders(theme.interactive.focus))
         .foreground(theme.base.text)
+        .background(theme.base.canvas)
         .highlighted_color(theme.interactive.focus)
         .highlighted_str("> ")
         .scroll(true)
         .rows(rows.build())
         .selected_line(selected);
     list.attr(Attribute::Focus, AttrValue::Flag(true));
-    list.view(frame, chunks[1]);
+    list.view(frame, content[0]);
+
+    render_project_detail_panel(frame, content[1], app);
 
     let mut footer = Label::default()
-        .text("n: new project  Enter: select  q: quit")
+        .text("n: new  r: rename  x: delete  Enter: open  j/k: navigate  q: quit")
         .alignment(Alignment::Center)
         .foreground(theme.base.text_muted)
         .background(theme.base.canvas);
     footer.view(frame, chunks[2]);
+}
+
+fn render_project_detail_panel(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let theme = app.theme;
+
+    let selected = app.project_list.get(app.selected_project_index);
+    let cache: Option<&ProjectDetailCache> = app.project_detail_cache.as_ref();
+
+    let mut lines: Vec<TextSpan> = Vec::new();
+
+    if let Some(project) = selected {
+        lines.push(TextSpan::new("PROJECT").fg(theme.base.header).bold());
+        lines.push(TextSpan::new(detail_kv("Name", &project.name)).fg(theme.base.text));
+
+        let path_str = project.path.to_string_lossy();
+        let path_short = clamp_text(&path_str, 55);
+        lines.push(TextSpan::new(detail_kv("Path", &path_short)).fg(theme.base.text_muted));
+        lines.push(TextSpan::new(""));
+
+        if let Some(c) = cache {
+            if c.project_name == project.name {
+                lines.push(TextSpan::new("CONTENTS").fg(theme.base.header).bold());
+                lines.push(
+                    TextSpan::new(detail_kv("Tasks", &c.task_count.to_string()))
+                        .fg(theme.base.text),
+                );
+                lines.push(
+                    TextSpan::new(detail_kv("Running", &c.running_count.to_string()))
+                        .fg(theme.status_color("running")),
+                );
+                lines.push(
+                    TextSpan::new(detail_kv("Repos", &c.repo_count.to_string()))
+                        .fg(theme.base.text),
+                );
+                lines.push(
+                    TextSpan::new(detail_kv("Columns", &c.category_count.to_string()))
+                        .fg(theme.base.text),
+                );
+                lines.push(TextSpan::new(""));
+                lines.push(TextSpan::new("FILE").fg(theme.base.header).bold());
+                lines.push(
+                    TextSpan::new(detail_kv("Size", &format!("{} KB", c.file_size_kb)))
+                        .fg(theme.base.text_muted),
+                );
+            }
+        } else {
+            lines.push(TextSpan::new("  (loading…)").fg(theme.base.text_muted));
+        }
+
+        lines.push(TextSpan::new(""));
+        lines.push(TextSpan::new("ACTIONS").fg(theme.base.header).bold());
+        lines.push(
+            TextSpan::new("  Enter open  r rename  x delete  n new").fg(theme.base.text_muted),
+        );
+    } else {
+        lines.push(TextSpan::new("No project selected").fg(theme.base.text_muted));
+    }
+
+    let mut paragraph = Paragraph::default()
+        .title("Details", Alignment::Left)
+        .borders(rounded_borders(theme.base.text_muted))
+        .foreground(theme.base.text)
+        .background(theme.base.canvas)
+        .wrap(true)
+        .text(lines);
+    paragraph.view(frame, area);
 }
 
 fn render_board(frame: &mut Frame<'_>, app: &App) {
@@ -562,7 +645,11 @@ fn render_dialog(frame: &mut Frame<'_>, app: &App) {
         ActiveDialog::CategoryInput(_) => (60, 40),
         ActiveDialog::CategoryColor(_) => (60, 58),
         ActiveDialog::DeleteCategory(_) => (60, 40),
-        ActiveDialog::NewProject(_) => (60, 35),
+        ActiveDialog::NewProject(_) => (60, 40),
+        ActiveDialog::RenameProject(_) => (60, 40),
+        ActiveDialog::DeleteProject(_) => (60, 35),
+        ActiveDialog::RenameRepo(_) => (60, 40),
+        ActiveDialog::DeleteRepo(_) => (60, 35),
         _ => (60, 45),
     };
     let anchor = if matches!(app.active_dialog, ActiveDialog::CommandPalette(_)) {
@@ -618,6 +705,18 @@ fn render_dialog(frame: &mut Frame<'_>, app: &App) {
         }
         ActiveDialog::NewProject(state) => {
             render_new_project_dialog(frame, dialog_area, app, state)
+        }
+        ActiveDialog::RenameProject(state) => {
+            render_rename_project_dialog(frame, dialog_area, app, state)
+        }
+        ActiveDialog::DeleteProject(state) => {
+            render_delete_project_dialog(frame, dialog_area, app, state)
+        }
+        ActiveDialog::RenameRepo(state) => {
+            render_rename_repo_dialog(frame, dialog_area, app, state)
+        }
+        ActiveDialog::DeleteRepo(state) => {
+            render_delete_repo_dialog(frame, dialog_area, app, state)
         }
         ActiveDialog::MoveTask(_) | ActiveDialog::None | ActiveDialog::Help => {}
     }
@@ -971,17 +1070,297 @@ fn render_new_project_dialog(
     frame: &mut Frame<'_>,
     area: Rect,
     app: &App,
-    state: &crate::app::NewProjectDialogState,
+    state: &NewProjectDialogState,
 ) {
+    let theme = app.theme;
+    let surface = dialog_surface(theme);
+
+    let mut panel =
+        dialog_panel("New Project", Alignment::Center, theme, surface).text([TextSpan::from("")]);
+    panel.view(frame, area);
+
+    let panel_inner = inset_rect(area, 1, 1);
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Min(0),
+        ])
+        .split(panel_inner);
+
     render_input_component(
         frame,
-        area,
-        "Project Name",
+        layout[0],
+        "Name",
         &state.name_input,
-        true,
-        dialog_surface(app.theme),
-        app.theme,
+        matches!(state.focused_field, NewProjectField::Name),
+        surface,
+        theme,
     );
+
+    let buttons = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(layout[2]);
+
+    render_action_button(
+        frame,
+        buttons[0],
+        "Create",
+        matches!(state.focused_field, NewProjectField::Create),
+        false,
+        app,
+    );
+    render_action_button(
+        frame,
+        buttons[1],
+        "Cancel",
+        matches!(state.focused_field, NewProjectField::Cancel),
+        false,
+        app,
+    );
+
+    let mut hint = Label::default()
+        .text("Tab: next field  Enter: confirm  Esc: cancel")
+        .alignment(Alignment::Center)
+        .foreground(theme.base.text_muted)
+        .background(surface);
+    hint.view(frame, layout[3]);
+}
+
+fn render_rename_project_dialog(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    app: &App,
+    state: &RenameProjectDialogState,
+) {
+    let theme = app.theme;
+    let surface = dialog_surface(theme);
+
+    let mut panel = dialog_panel("Rename Project", Alignment::Center, theme, surface)
+        .text([TextSpan::from("")]);
+    panel.view(frame, area);
+
+    let panel_inner = inset_rect(area, 1, 1);
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Min(0),
+        ])
+        .split(panel_inner);
+
+    render_input_component(
+        frame,
+        layout[0],
+        "New Name",
+        &state.name_input,
+        matches!(state.focused_field, RenameProjectField::Name),
+        surface,
+        theme,
+    );
+
+    let buttons = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(layout[2]);
+
+    render_action_button(
+        frame,
+        buttons[0],
+        "Rename",
+        matches!(state.focused_field, RenameProjectField::Confirm),
+        false,
+        app,
+    );
+    render_action_button(
+        frame,
+        buttons[1],
+        "Cancel",
+        matches!(state.focused_field, RenameProjectField::Cancel),
+        false,
+        app,
+    );
+
+    let mut hint = Label::default()
+        .text("Tab: next field  Enter: confirm  Esc: cancel")
+        .alignment(Alignment::Center)
+        .foreground(theme.base.text_muted)
+        .background(surface);
+    hint.view(frame, layout[3]);
+}
+
+fn render_delete_project_dialog(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    app: &App,
+    state: &DeleteProjectDialogState,
+) {
+    let theme = app.theme;
+    let surface = dialog_surface(theme);
+
+    let mut panel = dialog_panel("Delete Project", Alignment::Center, theme, surface)
+        .text([TextSpan::from("")]);
+    panel.view(frame, area);
+
+    let panel_inner = inset_rect(area, 1, 1);
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Min(1),
+            Constraint::Length(3),
+            Constraint::Length(2),
+        ])
+        .split(panel_inner);
+
+    let mut summary = Paragraph::default()
+        .foreground(theme.base.text)
+        .background(surface)
+        .wrap(true)
+        .alignment(Alignment::Center)
+        .text([TextSpan::from(format!(
+            "Permanently delete '{}'?\nAll tasks will be lost.",
+            state.project_name
+        ))]);
+    summary.view(frame, layout[0]);
+
+    let buttons = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(layout[2]);
+
+    render_action_button(frame, buttons[0], "Delete", true, true, app);
+    render_action_button(frame, buttons[1], "Cancel", false, false, app);
+
+    let mut hint = Label::default()
+        .text("Enter: confirm delete  Esc: cancel")
+        .alignment(Alignment::Center)
+        .foreground(theme.base.text_muted)
+        .background(surface);
+    hint.view(frame, layout[3]);
+}
+
+fn render_rename_repo_dialog(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    app: &App,
+    state: &RenameRepoDialogState,
+) {
+    let theme = app.theme;
+    let surface = dialog_surface(theme);
+
+    let mut panel =
+        dialog_panel("Rename Repo", Alignment::Center, theme, surface).text([TextSpan::from("")]);
+    panel.view(frame, area);
+
+    let panel_inner = inset_rect(area, 1, 1);
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Min(0),
+        ])
+        .split(panel_inner);
+
+    render_input_component(
+        frame,
+        layout[0],
+        "Display Name",
+        &state.name_input,
+        matches!(state.focused_field, RenameRepoField::Name),
+        surface,
+        theme,
+    );
+
+    let buttons = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(layout[2]);
+
+    render_action_button(
+        frame,
+        buttons[0],
+        "Rename",
+        matches!(state.focused_field, RenameRepoField::Confirm),
+        false,
+        app,
+    );
+    render_action_button(
+        frame,
+        buttons[1],
+        "Cancel",
+        matches!(state.focused_field, RenameRepoField::Cancel),
+        false,
+        app,
+    );
+
+    let mut hint = Label::default()
+        .text("Tab: next field  Enter: confirm  Esc: cancel")
+        .alignment(Alignment::Center)
+        .foreground(theme.base.text_muted)
+        .background(surface);
+    hint.view(frame, layout[3]);
+}
+
+fn render_delete_repo_dialog(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    app: &App,
+    state: &DeleteRepoDialogState,
+) {
+    let theme = app.theme;
+    let surface = dialog_surface(theme);
+
+    let mut panel =
+        dialog_panel("Remove Repo", Alignment::Center, theme, surface).text([TextSpan::from("")]);
+    panel.view(frame, area);
+
+    let panel_inner = inset_rect(area, 1, 1);
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Min(1),
+            Constraint::Length(3),
+            Constraint::Length(2),
+        ])
+        .split(panel_inner);
+
+    let mut summary = Paragraph::default()
+        .foreground(theme.base.text)
+        .background(surface)
+        .wrap(true)
+        .alignment(Alignment::Center)
+        .text([TextSpan::from(format!(
+            "Remove repo '{}' from this project?\n(Only allowed if no tasks reference it.)",
+            state.repo_name
+        ))]);
+    summary.view(frame, layout[0]);
+
+    let buttons = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(layout[2]);
+
+    render_action_button(frame, buttons[0], "Remove", true, true, app);
+    render_action_button(frame, buttons[1], "Cancel", false, false, app);
+
+    let mut hint = Label::default()
+        .text("Enter: confirm  Esc: cancel")
+        .alignment(Alignment::Center)
+        .foreground(theme.base.text_muted)
+        .background(surface);
+    hint.view(frame, layout[3]);
 }
 
 fn render_category_color_dialog(
@@ -1691,12 +2070,14 @@ fn render_settings_sidebar(frame: &mut Frame<'_>, area: Rect, app: &App) {
         SettingsSection::CategoryColors,
         SettingsSection::Keybindings,
         SettingsSection::General,
+        SettingsSection::Repos,
     ] {
         let label = match section {
             SettingsSection::Theme => "Theme",
             SettingsSection::CategoryColors => "Category Colors",
             SettingsSection::Keybindings => "Keybindings",
             SettingsSection::General => "General",
+            SettingsSection::Repos => "Repos",
         };
         let prefix = if section == active_section {
             "> "
@@ -1712,6 +2093,7 @@ fn render_settings_sidebar(frame: &mut Frame<'_>, area: Rect, app: &App) {
         SettingsSection::CategoryColors => 1,
         SettingsSection::Keybindings => 2,
         SettingsSection::General => 3,
+        SettingsSection::Repos => 4,
     };
 
     let mut list = List::default()
@@ -1738,6 +2120,7 @@ fn render_settings_active_section(frame: &mut Frame<'_>, area: Rect, app: &App) 
         SettingsSection::CategoryColors => render_settings_category_colors(frame, area, app),
         SettingsSection::Keybindings => render_settings_keybindings(frame, area, app),
         SettingsSection::General => render_settings_general(frame, area, app),
+        SettingsSection::Repos => render_settings_repos(frame, area, app),
     }
 }
 
@@ -1875,6 +2258,53 @@ fn render_settings_general(frame: &mut Frame<'_>, area: Rect, app: &App) {
     list.view(frame, area);
 }
 
+fn render_settings_repos(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let theme = app.theme;
+    let selected_field = app
+        .settings_view_state
+        .as_ref()
+        .map(|s| s.repos_selected_field)
+        .unwrap_or(0)
+        .min(app.repos.len().saturating_sub(1));
+
+    let mut rows = TableBuilder::default();
+
+    if app.repos.is_empty() {
+        rows.add_col(TextSpan::from("  No repos configured for this project"))
+            .add_row();
+    } else {
+        for (index, repo) in app.repos.iter().enumerate() {
+            let prefix = if index == selected_field { "> " } else { "  " };
+            let path_short = clamp_text(&repo.path, 45);
+            let base = repo
+                .default_base
+                .as_deref()
+                .filter(|b| !b.is_empty())
+                .unwrap_or("—");
+            rows.add_col(TextSpan::new(format!(
+                "{}{:<20} {} [{}]",
+                prefix,
+                clamp_text(&repo.name, 20),
+                path_short,
+                base
+            )))
+            .add_row();
+        }
+    }
+
+    let mut list = List::default()
+        .title("Repositories", Alignment::Left)
+        .borders(rounded_borders(theme.interactive.focus))
+        .foreground(theme.base.text)
+        .highlighted_color(theme.interactive.focus)
+        .highlighted_str("> ")
+        .scroll(true)
+        .rows(rows.build())
+        .selected_line(selected_field);
+    list.attr(Attribute::Focus, AttrValue::Flag(true));
+    list.view(frame, area);
+}
+
 fn render_settings_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let theme = app.theme;
     let active_section = app
@@ -1890,6 +2320,7 @@ fn render_settings_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
         }
         SettingsSection::Keybindings => "h/l: section  Esc: close",
         SettingsSection::General => "j/k: select  h/l: section  Esc: close",
+        SettingsSection::Repos => "j/k: select  r: rename  x: remove  h/l: section  Esc: close",
     };
 
     let mut footer = Label::default()


### PR DESCRIPTION
## Summary

- Fixed New Project dialog with proper panel/buttons/hint styling
- Added Rename + Delete project functionality with keybindings (r/x) and confirmation dialogs
- Added Project list detail split-panel view (40% list / 60% stats)
- Added Repo management in Settings with new Repos section (rename/remove)

## Changes

- `src/projects.rs`: Added rename/remove backend functions
- `src/db/mod.rs`: Added DB functions for repo management
- `src/app/state.rs`: Added state for project management
- `src/app/messages.rs`: Added messages for rename/delete/confirm dialogs
- `src/app/dialogs.rs`: Added dialog states for rename/confirm
- `src/app/mod.rs`: Added dialog handling logic
- `src/keybindings.rs`: Added r/x keybindings for rename/delete
- `src/ui.rs`: Added project list split-panel view, improved New Project dialog

## Testing

- All 132 unit tests pass
- All 3 integration tests pass
- Build is clean