### PR TITLE
feat: add universal mouse support with z-ordered interaction layer

### DIFF
--- a/src/app/interaction.rs
+++ b/src/app/interaction.rs
@@ -1,0 +1,178 @@
+use tuirealm::ratatui::layout::Rect;
+
+use super::messages::Message;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum InteractionLayer {
+    Base,
+    Overlay,
+    Dialog,
+    ContextMenu,
+}
+
+impl InteractionLayer {
+    fn priority(self) -> u8 {
+        match self {
+            Self::Base => 0,
+            Self::Overlay => 1,
+            Self::Dialog => 2,
+            Self::ContextMenu => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum InteractionKind {
+    Hover,
+    LeftClick,
+    RightClick,
+    Scroll,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct InteractionNode {
+    pub rect: Rect,
+    pub message: Message,
+    pub layer: InteractionLayer,
+    pub hoverable: bool,
+    pub left_clickable: bool,
+    pub right_clickable: bool,
+    pub scrollable: bool,
+}
+
+impl InteractionNode {
+    pub fn click(layer: InteractionLayer, rect: Rect, message: Message) -> Self {
+        Self {
+            rect,
+            message,
+            layer,
+            hoverable: true,
+            left_clickable: true,
+            right_clickable: false,
+            scrollable: false,
+        }
+    }
+
+    pub fn task(layer: InteractionLayer, rect: Rect, message: Message) -> Self {
+        Self {
+            rect,
+            message,
+            layer,
+            hoverable: true,
+            left_clickable: true,
+            right_clickable: true,
+            scrollable: false,
+        }
+    }
+
+    fn contains(&self, col: u16, row: u16) -> bool {
+        col >= self.rect.x
+            && col < self.rect.x + self.rect.width
+            && row >= self.rect.y
+            && row < self.rect.y + self.rect.height
+    }
+
+    fn supports(&self, kind: InteractionKind) -> bool {
+        match kind {
+            InteractionKind::Hover => self.hoverable,
+            InteractionKind::LeftClick => self.left_clickable,
+            InteractionKind::RightClick => self.right_clickable,
+            InteractionKind::Scroll => self.scrollable,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct InteractionMap {
+    nodes: Vec<InteractionNode>,
+}
+
+impl InteractionMap {
+    pub fn clear(&mut self) {
+        self.nodes.clear();
+    }
+
+    pub fn register(&mut self, node: InteractionNode) {
+        self.nodes.push(node);
+    }
+
+    pub fn register_click(&mut self, layer: InteractionLayer, rect: Rect, message: Message) {
+        self.register(InteractionNode::click(layer, rect, message));
+    }
+
+    pub fn register_task(&mut self, layer: InteractionLayer, rect: Rect, message: Message) {
+        self.register(InteractionNode::task(layer, rect, message));
+    }
+
+    pub fn resolve_message(&self, col: u16, row: u16, kind: InteractionKind) -> Option<Message> {
+        self.resolve_node(col, row, kind)
+            .map(|node| node.message.clone())
+    }
+
+    pub fn resolve_node(
+        &self,
+        col: u16,
+        row: u16,
+        kind: InteractionKind,
+    ) -> Option<&InteractionNode> {
+        let mut best: Option<(usize, &InteractionNode)> = None;
+        for (idx, node) in self.nodes.iter().enumerate() {
+            if !node.contains(col, row) || !node.supports(kind) {
+                continue;
+            }
+            match best {
+                None => best = Some((idx, node)),
+                Some((best_idx, best_node)) => {
+                    let has_higher_layer = node.layer.priority() > best_node.layer.priority();
+                    let same_layer_later_registration =
+                        node.layer.priority() == best_node.layer.priority() && idx > best_idx;
+                    if has_higher_layer || same_layer_later_registration {
+                        best = Some((idx, node));
+                    }
+                }
+            }
+        }
+        best.map(|(_, node)| node)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InteractionKind, InteractionLayer, InteractionMap};
+    use crate::app::Message;
+    use tuirealm::ratatui::layout::Rect;
+
+    #[test]
+    fn resolve_prefers_higher_layer() {
+        let mut map = InteractionMap::default();
+        let rect = Rect::new(10, 10, 5, 2);
+
+        map.register_click(InteractionLayer::Base, rect, Message::ProjectListSelectUp);
+        map.register_click(InteractionLayer::Dialog, rect, Message::DismissDialog);
+
+        let message = map.resolve_message(11, 10, InteractionKind::LeftClick);
+        assert_eq!(message, Some(Message::DismissDialog));
+    }
+
+    #[test]
+    fn resolve_prefers_latest_within_same_layer() {
+        let mut map = InteractionMap::default();
+        let rect = Rect::new(4, 4, 4, 1);
+
+        map.register_click(InteractionLayer::Base, rect, Message::ProjectListSelectUp);
+        map.register_click(InteractionLayer::Base, rect, Message::ProjectListSelectDown);
+
+        let message = map.resolve_message(5, 4, InteractionKind::LeftClick);
+        assert_eq!(message, Some(Message::ProjectListSelectDown));
+    }
+
+    #[test]
+    fn task_nodes_support_right_click() {
+        let mut map = InteractionMap::default();
+        let rect = Rect::new(0, 0, 10, 10);
+        map.register_task(InteractionLayer::Base, rect, Message::SelectTask(1, 2));
+
+        let message = map.resolve_message(2, 2, InteractionKind::RightClick);
+        assert_eq!(message, Some(Message::SelectTask(1, 2)));
+    }
+}

--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 use crossterm::event::{KeyEvent, MouseEvent};
 
 use super::state::{
-    CategoryInputField, DeleteTaskField, NewProjectField, NewTaskField, RenameProjectField,
-    RenameRepoField,
+    CategoryInputField, DeleteTaskField, DetailFocus, NewProjectField, NewTaskField,
+    RenameProjectField, RenameRepoField, SettingsSection,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -34,10 +34,15 @@ pub enum Message {
     SettingsToggle,
     SettingsDecreaseItem,
     SettingsResetItem,
+    SettingsSelectSection(SettingsSection),
+    SettingsSelectGeneralField(usize),
+    SettingsSelectCategoryColor(usize),
+    SettingsSelectRepo(usize),
     DismissDialog,
     FocusColumn(usize),
     SelectTask(usize, usize),
     SelectTaskInSidePanel(usize),
+    FocusSidePanel(DetailFocus),
     ToggleSidePanelCategoryCollapse,
     OpenAddCategoryDialog,
     OpenRenameCategoryDialog,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,6 @@
 pub mod actions;
 pub mod dialogs;
+pub mod interaction;
 pub mod messages;
 pub mod polling;
 pub mod runtime;
@@ -15,13 +16,14 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Local, Utc};
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use tokio::task::JoinHandle;
 use tracing::warn;
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::{ListState, ScrollbarState};
 use uuid::Uuid;
 
+use self::interaction::{InteractionKind, InteractionMap};
 pub use self::messages::Message;
 pub use self::state::{
     ActiveDialog, ArchiveTaskDialogState, CATEGORY_COLOR_PALETTE, CategoryColorDialogState,
@@ -99,7 +101,7 @@ pub struct App {
     pub column_scroll_states: Vec<ScrollbarState>,
     pub active_dialog: ActiveDialog,
     pub footer_notice: Option<String>,
-    pub hit_test_map: Vec<(Rect, Message)>,
+    pub interaction_map: InteractionMap,
     pub hovered_message: Option<Message>,
     pub context_menu: Option<ContextMenuState>,
     pub current_view: View,
@@ -135,6 +137,7 @@ pub struct App {
     pub settings_view_state: Option<SettingsViewState>,
     pub category_edit_mode: bool,
     pub project_detail_cache: Option<ProjectDetailCache>,
+    last_click: Option<(u16, u16, Instant)>,
 }
 
 fn load_project_detail(info: &crate::projects::ProjectInfo) -> Option<ProjectDetailCache> {
@@ -214,7 +217,7 @@ impl App {
             column_scroll_states: Vec::new(),
             active_dialog: ActiveDialog::None,
             footer_notice: None,
-            hit_test_map: Vec::new(),
+            interaction_map: InteractionMap::default(),
             hovered_message: None,
             context_menu: None,
             current_view: View::ProjectList,
@@ -250,6 +253,7 @@ impl App {
             settings_view_state: None,
             category_edit_mode: false,
             project_detail_cache: None,
+            last_click: None,
         };
 
         app.refresh_data()?;
@@ -541,7 +545,7 @@ impl App {
             Message::Resize(w, h) => {
                 self.viewport = (w, h);
                 self.layout_epoch = self.layout_epoch.saturating_add(1);
-                self.hit_test_map.clear();
+                self.interaction_map.clear();
                 self.context_menu = None;
                 self.hovered_message = None;
             }
@@ -828,6 +832,30 @@ impl App {
                     self.save_settings_with_notice();
                 }
             }
+            Message::SettingsSelectSection(section) => {
+                if let Some(state) = &mut self.settings_view_state {
+                    state.active_section = section;
+                }
+            }
+            Message::SettingsSelectGeneralField(index) => {
+                if let Some(state) = &mut self.settings_view_state {
+                    state.active_section = SettingsSection::General;
+                    state.general_selected_field = index.min(3);
+                }
+            }
+            Message::SettingsSelectCategoryColor(index) => {
+                if let Some(state) = &mut self.settings_view_state {
+                    state.active_section = SettingsSection::CategoryColors;
+                    state.category_color_selected =
+                        index.min(self.categories.len().saturating_sub(1));
+                }
+            }
+            Message::SettingsSelectRepo(index) => {
+                if let Some(state) = &mut self.settings_view_state {
+                    state.active_section = SettingsSection::Repos;
+                    state.repos_selected_field = index.min(self.repos.len().saturating_sub(1));
+                }
+            }
             Message::FocusColumn(index) => {
                 if index < self.categories.len() {
                     self.focused_column = index;
@@ -843,6 +871,10 @@ impl App {
             Message::SelectTaskInSidePanel(index) => {
                 let rows = self.side_panel_rows();
                 self.sync_side_panel_selection_at(&rows, index, true);
+                self.detail_focus = DetailFocus::List;
+            }
+            Message::FocusSidePanel(focus) => {
+                self.detail_focus = focus;
             }
             Message::ToggleSidePanelCategoryCollapse => self.toggle_side_panel_category_collapse(),
             Message::OpenAddCategoryDialog => {
@@ -1548,7 +1580,221 @@ impl App {
         Ok(())
     }
 
-    fn handle_mouse(&mut self, _mouse: MouseEvent) -> Result<()> {
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
+        self.mouse_seen = true;
+        self.last_mouse_event = Some(mouse);
+
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                self.hovered_message = None;
+
+                if let Some((lc, lr, lt)) = self.last_click
+                    && lc == mouse.column
+                    && lr == mouse.row
+                    && lt.elapsed() < Duration::from_millis(400)
+                {
+                    self.last_click = None;
+                    return self.update(Message::AttachSelectedTask);
+                }
+                self.last_click = Some((mouse.column, mouse.row, Instant::now()));
+
+                let hit = self.interaction_map.resolve_message(
+                    mouse.column,
+                    mouse.row,
+                    InteractionKind::LeftClick,
+                );
+
+                if let Some(msg) = hit {
+                    self.context_menu = None;
+                    self.update(msg)?;
+                }
+            }
+
+            MouseEventKind::Down(MouseButton::Right) => {
+                let mut found_task = false;
+                if let Some(Message::SelectTask(col, task_idx)) = self
+                    .interaction_map
+                    .resolve_message(mouse.column, mouse.row, InteractionKind::RightClick)
+                {
+                    let category = self.categories.get(col);
+                    if let Some(category) = category {
+                        let mut tasks: Vec<Task> = self
+                            .tasks
+                            .iter()
+                            .filter(|t| t.category_id == category.id)
+                            .cloned()
+                            .collect();
+                        tasks.sort_by_key(|t| t.position);
+                        if let Some(task) = tasks.get(task_idx) {
+                            self.context_menu = Some(ContextMenuState {
+                                position: (mouse.column, mouse.row),
+                                task_id: task.id,
+                                task_column: col,
+                                items: vec![
+                                    ContextMenuItem::Attach,
+                                    ContextMenuItem::Delete,
+                                    ContextMenuItem::Move,
+                                ],
+                                selected_index: 0,
+                            });
+                            found_task = true;
+                        }
+                    }
+                }
+                if !found_task {
+                    self.context_menu = None;
+                }
+            }
+
+            MouseEventKind::Moved => {
+                let hit = self.interaction_map.resolve_message(
+                    mouse.column,
+                    mouse.row,
+                    InteractionKind::Hover,
+                );
+                self.hovered_message = hit;
+            }
+
+            MouseEventKind::ScrollDown => {
+                self.handle_scroll(mouse.column, mouse.row, 1)?;
+            }
+            MouseEventKind::ScrollUp => {
+                self.handle_scroll(mouse.column, mouse.row, -1)?;
+            }
+
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    fn handle_scroll(&mut self, col: u16, row: u16, delta: i32) -> Result<()> {
+        match self.current_view {
+            View::Board => {
+                if self.view_mode == ViewMode::SidePanel {
+                    let hovered =
+                        self.interaction_map
+                            .resolve_message(col, row, InteractionKind::Hover);
+                    match hovered {
+                        Some(Message::SelectTaskInSidePanel(index)) => {
+                            self.detail_focus = DetailFocus::List;
+                            let rows = self.side_panel_rows();
+                            if !rows.is_empty() {
+                                let current = index.min(rows.len() - 1);
+                                let next = if delta > 0 {
+                                    (current + 1).min(rows.len() - 1)
+                                } else {
+                                    current.saturating_sub(1)
+                                };
+                                self.sync_side_panel_selection_at(&rows, next, true);
+                            }
+                            return Ok(());
+                        }
+                        Some(Message::FocusSidePanel(DetailFocus::List)) => {
+                            self.detail_focus = DetailFocus::List;
+                            let rows = self.side_panel_rows();
+                            if !rows.is_empty() {
+                                let current = self.side_panel_selected_row.min(rows.len() - 1);
+                                let next = if delta > 0 {
+                                    (current + 1).min(rows.len() - 1)
+                                } else {
+                                    current.saturating_sub(1)
+                                };
+                                self.sync_side_panel_selection_at(&rows, next, true);
+                            }
+                            return Ok(());
+                        }
+                        Some(Message::FocusSidePanel(DetailFocus::Details)) => {
+                            self.detail_focus = DetailFocus::Details;
+                            if delta > 0 {
+                                self.scroll_details_down(1);
+                            } else {
+                                self.scroll_details_up(1);
+                            }
+                            return Ok(());
+                        }
+                        Some(Message::FocusSidePanel(DetailFocus::Log)) => {
+                            self.detail_focus = DetailFocus::Log;
+                            if delta > 0 {
+                                self.scroll_log_down(1);
+                            } else {
+                                self.scroll_log_up(1);
+                            }
+                            return Ok(());
+                        }
+                        _ => {}
+                    }
+
+                    let rows = self.side_panel_rows();
+                    match self.detail_focus {
+                        DetailFocus::List => {
+                            if !rows.is_empty() {
+                                let current = self.side_panel_selected_row.min(rows.len() - 1);
+                                let next = if delta > 0 {
+                                    (current + 1).min(rows.len() - 1)
+                                } else {
+                                    current.saturating_sub(1)
+                                };
+                                self.sync_side_panel_selection_at(&rows, next, true);
+                            }
+                        }
+                        DetailFocus::Details => {
+                            if delta > 0 {
+                                self.scroll_details_down(1);
+                            } else {
+                                self.scroll_details_up(1);
+                            }
+                        }
+                        DetailFocus::Log => {
+                            if delta > 0 {
+                                self.scroll_log_down(1);
+                            } else {
+                                self.scroll_log_up(1);
+                            }
+                        }
+                    }
+                    return Ok(());
+                }
+
+                if let Some(Message::SelectTask(column, _) | Message::FocusColumn(column)) = self
+                    .interaction_map
+                    .resolve_message(col, row, InteractionKind::Hover)
+                {
+                    self.focused_column = column;
+                }
+                let max = self.max_scroll_offset_for_column(self.focused_column);
+                let offset = self
+                    .scroll_offset_per_column
+                    .entry(self.focused_column)
+                    .or_insert(0);
+                if delta > 0 {
+                    *offset = (*offset + 1).min(max);
+                } else {
+                    *offset = offset.saturating_sub(1);
+                }
+            }
+            View::ProjectList => {
+                if delta > 0 {
+                    self.update(Message::ProjectListSelectDown)?;
+                } else {
+                    self.update(Message::ProjectListSelectUp)?;
+                }
+            }
+            View::Archive => {
+                if delta > 0 {
+                    self.update(Message::ArchiveSelectDown)?;
+                } else {
+                    self.update(Message::ArchiveSelectUp)?;
+                }
+            }
+            View::Settings => {
+                if delta > 0 {
+                    self.update(Message::SettingsNextItem)?;
+                } else {
+                    self.update(Message::SettingsPrevItem)?;
+                }
+            }
+        }
         Ok(())
     }
 
@@ -2828,13 +3074,16 @@ fn resolve_repo_for_creation(
 
 #[cfg(test)]
 mod tests {
+    use super::interaction::InteractionLayer;
     use super::*;
 
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
     use std::time::Instant;
 
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use crossterm::event::{
+        KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    };
     use tempfile::TempDir;
     use tuirealm::ratatui::widgets::ListState;
 
@@ -2886,6 +3135,15 @@ mod tests {
         KeyEvent::new(KeyCode::Enter, KeyModifiers::empty())
     }
 
+    fn mouse_event(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::empty(),
+        }
+    }
+
     fn category_positions(app: &App) -> Vec<(Uuid, i64)> {
         app.categories
             .iter()
@@ -2919,7 +3177,7 @@ mod tests {
             column_scroll_states: Vec::new(),
             active_dialog: ActiveDialog::None,
             footer_notice: None,
-            hit_test_map: Vec::new(),
+            interaction_map: InteractionMap::default(),
             hovered_message: None,
             context_menu: None,
             current_view: View::Board,
@@ -2955,6 +3213,7 @@ mod tests {
             settings_view_state: None,
             category_edit_mode: false,
             project_detail_cache: None,
+            last_click: None,
         };
 
         app.refresh_data()?;
@@ -3154,6 +3413,115 @@ mod tests {
             Some(0)
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_left_click_selects_task_from_interaction_map() -> Result<()> {
+        let (mut app, _repo_dir, _task_id, _category_ids) = test_app_with_middle_task()?;
+        app.focused_column = 0;
+        app.interaction_map.register_task(
+            InteractionLayer::Base,
+            Rect::new(10, 5, 20, 5),
+            Message::SelectTask(1, 0),
+        );
+
+        app.handle_mouse(mouse_event(MouseEventKind::Down(MouseButton::Left), 12, 6))?;
+
+        assert_eq!(app.focused_column, 1);
+        assert_eq!(app.selected_task_per_column.get(&1).copied(), Some(0));
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_scroll_down_moves_board_column_offset() -> Result<()> {
+        let (mut app, _repo_dir, _task_id, category_ids) = test_app_with_middle_task()?;
+        let repo_id = app.repos[0].id;
+        app.db
+            .add_task(repo_id, "feature/scroll-1", "Scroll 1", category_ids[1])?;
+        app.db
+            .add_task(repo_id, "feature/scroll-2", "Scroll 2", category_ids[1])?;
+        app.refresh_data()?;
+        app.focused_column = 1;
+
+        app.handle_mouse(mouse_event(MouseEventKind::ScrollDown, 20, 10))?;
+
+        assert_eq!(app.clamped_scroll_offset_for_column(1), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_right_click_opens_context_menu_for_task() -> Result<()> {
+        let (mut app, _repo_dir, task_id, _category_ids) = test_app_with_middle_task()?;
+        app.interaction_map.register_task(
+            InteractionLayer::Base,
+            Rect::new(10, 5, 20, 5),
+            Message::SelectTask(1, 0),
+        );
+
+        app.handle_mouse(mouse_event(MouseEventKind::Down(MouseButton::Right), 12, 6))?;
+
+        assert!(app.context_menu.is_some());
+        let menu = app
+            .context_menu
+            .as_ref()
+            .expect("context menu should exist");
+        assert_eq!(menu.task_column, 1);
+        assert_eq!(menu.task_id, task_id);
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_click_selects_side_panel_row() -> Result<()> {
+        let (mut app, _repo_dir, _task_id, _category_ids) = test_app_with_middle_task()?;
+        app.view_mode = ViewMode::SidePanel;
+        app.detail_focus = DetailFocus::Details;
+
+        app.interaction_map.register_click(
+            InteractionLayer::Base,
+            Rect::new(8, 8, 20, 1),
+            Message::SelectTaskInSidePanel(2),
+        );
+
+        app.handle_mouse(mouse_event(MouseEventKind::Down(MouseButton::Left), 9, 8))?;
+
+        assert_eq!(app.side_panel_selected_row, 2);
+        assert_eq!(app.detail_focus, DetailFocus::List);
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_scroll_moves_side_panel_selection_when_in_side_panel_mode() -> Result<()> {
+        let (mut app, _repo_dir, _task_id, _category_ids) = test_app_with_middle_task()?;
+        app.view_mode = ViewMode::SidePanel;
+        app.detail_focus = DetailFocus::List;
+        app.side_panel_selected_row = 0;
+
+        app.handle_mouse(mouse_event(MouseEventKind::ScrollDown, 20, 10))?;
+        assert_eq!(app.side_panel_selected_row, 1);
+
+        app.handle_mouse(mouse_event(MouseEventKind::ScrollUp, 20, 10))?;
+        assert_eq!(app.side_panel_selected_row, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_scroll_over_side_panel_list_area_forces_list_scroll() -> Result<()> {
+        let (mut app, _repo_dir, _task_id, _category_ids) = test_app_with_middle_task()?;
+        app.view_mode = ViewMode::SidePanel;
+        app.detail_focus = DetailFocus::Details;
+        app.side_panel_selected_row = 0;
+
+        app.interaction_map.register_click(
+            InteractionLayer::Base,
+            Rect::new(4, 4, 30, 10),
+            Message::FocusSidePanel(DetailFocus::List),
+        );
+
+        app.handle_mouse(mouse_event(MouseEventKind::ScrollDown, 5, 5))?;
+
+        assert_eq!(app.detail_focus, DetailFocus::List);
+        assert_eq!(app.side_panel_selected_row, 1);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive mouse support to the TUI kanban board, replacing the ad-hoc `hit_test_map` with a centralized interaction system.

## Changes

### Infrastructure
- **New module**: `src/app/interaction.rs` with z-ordered interaction layer
  - `InteractionLayer` enum: Base, Overlay, Dialog, ContextMenu (with priority ordering)
  - `InteractionKind`: Hover, LeftClick, RightClick, Scroll
  - `InteractionNode`: Geometry + capability flags for each interaction
  - `InteractionMap`: Z-ordered hit-testing and message resolution
  - Helper constructors: `click()`, `task()`
  - Unit tests for layer priority and interaction resolution

### App Integration
- Replaced `hit_test_map: Vec<(Rect, Message)>` with `interaction_map: InteractionMap`
- Refactored `handle_mouse()` to use interaction layer resolution
- Refactored `handle_scroll()` with layer-aware event routing
- Added `last_click` tracking for double-click detection
- Double-click on task = attach (switch tmux client)
- Right-click on task = context menu (Attach/Delete/Move)

### UI Registration (all now mouse-clickable)
- **Board**: Task cards, column headers
- **Project list**: Project rows
- **Side panel**: List rows, details pane, log pane (with focus targets)
- **Settings**: Sidebar sections, category colors, general fields, repos
- **Dialogs**: Action buttons, command palette items, context menu
- **Hover highlighting**: All interactive components

### New Messages
- `SettingsSelectSection`, `SettingsSelectGeneralField`
- `SettingsSelectCategoryColor`, `SettingsSelectRepo`
- `FocusSidePanel(DetailFocus)`

## Testing
- 149 tests passing (including 6 new mouse interaction tests)
- New tests:
  - `mouse_left_click_selects_task_from_interaction_map`
  - `mouse_scroll_down_moves_board_column_offset`
  - `mouse_right_click_opens_context_menu_for_task`
  - `mouse_click_selects_side_panel_row`
  - `mouse_scroll_moves_side_panel_selection_when_in_side_panel_mode`
  - `mouse_scroll_over_side_panel_list_area_forces_list_scroll`

## Verification
- `cargo check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test --lib` ✓ (149 passed)
- `cargo build --release` ✓

## Usage
Enable mouse in tmux: `tmux set -g mouse on`

Then you can:
- **Click** task/project/row to select
- **Double-click** task to attach
- **Right-click** task for context menu
- **Scroll** wheel to navigate lists and columns
- **Hover** over items to see focus highlight

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)