### PR TITLE
ci: follow @openai/codex npm pattern with scoped platform packages

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -216,6 +216,7 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+          scope: "@qrafty-ai"
 
       - name: Update npm
         run: npm install -g npm@latest

--- a/npm/bin/opencode-kanban.js
+++ b/npm/bin/opencode-kanban.js
@@ -11,8 +11,8 @@ const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);
 
 const PLATFORM_PACKAGE_BY_TARGET = {
-  "x86_64-unknown-linux-gnu": "qrafty-ai-opencode-kanban-linux-x64",
-  "aarch64-apple-darwin": "qrafty-ai-opencode-kanban-darwin-arm64",
+  "x86_64-unknown-linux-gnu": "@qrafty-ai/opencode-kanban-linux-x64",
+  "aarch64-apple-darwin": "@qrafty-ai/opencode-kanban-darwin-arm64",
 };
 
 function detectTargetTriple() {

--- a/npm/scripts/build_npm_package.py
+++ b/npm/scripts/build_npm_package.py
@@ -102,7 +102,7 @@ def stage_main_package(
     package_json["version"] = version
     package_json["files"] = ["bin"]
     package_json["optionalDependencies"] = {
-        f"{PACKAGE_FILENAME}-{platform_tag}": f"npm:{PACKAGE_NAME}@{version}-{platform_tag}"
+        f"{PACKAGE_NAME}-{platform_tag}": f"npm:{PACKAGE_NAME}@{version}-{platform_tag}"
         for platform_tag in PLATFORM_PACKAGES
     }
 


### PR DESCRIPTION
Switch optional dependency keys from unscoped qrafty-ai-opencode-kanban-linux-x64 to scoped @qrafty-ai/opencode-kanban-linux-x64. Add scope to setup-node for OIDC publishing.