### PR TITLE
fix(ci): fix AUR SSH auth — base64-encode secret, publish manually

### DIFF
--- a/.github/workflows/publish-aur.yaml
+++ b/.github/workflows/publish-aur.yaml
@@ -46,11 +46,11 @@ jobs:
 
       - name: Stamp PKGBUILD
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA256: ${{ steps.sha256.outputs.sha256 }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
-          SHA256="${{ steps.sha256.outputs.sha256 }}"
-
           python3 - <<'PY'
           import os, re
           from pathlib import Path
@@ -68,18 +68,75 @@ jobs:
           pkgbuild.write_text(text)
           print(f"Stamped PKGBUILD: version={version}, sha256={sha256}")
           PY
+
+      - name: Generate .SRCINFO
+        shell: bash
         env:
           VERSION: ${{ steps.version.outputs.version }}
           SHA256: ${{ steps.sha256.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
 
-      - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
-        with:
-          pkgname: opencode-kanban
-          pkgbuild: aur/PKGBUILD
-          commit_username: qrafty-ai[bot]
-          commit_email: github-actions@qrafty.ai
-          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: "Update to v${{ steps.version.outputs.version }}"
-          allow_empty_commits: false
-          force_push: false
+          version = os.environ["VERSION"]
+          sha256  = os.environ["SHA256"]
+          pkgname = "opencode-kanban"
+          url     = f"https://github.com/qrafty-ai/{pkgname}"
+
+          srcinfo = (
+              f"pkgbase = {pkgname}\n"
+              f"\tpkgdesc = Terminal kanban board for managing OpenCode tmux sessions and Git worktrees\n"
+              f"\tpkgver = {version}\n"
+              f"\tpkgrel = 1\n"
+              f"\turl = {url}\n"
+              f"\tarch = x86_64\n"
+              f"\tarch = aarch64\n"
+              f"\tlicense = MIT\n"
+              f"\tmakedepends = rust\n"
+              f"\tmakedepends = cargo\n"
+              f"\tdepends = tmux\n"
+              f"\tsource = {pkgname}-{version}.tar.gz::{url}/archive/refs/tags/v{version}.tar.gz\n"
+              f"\tsha256sums = {sha256}\n"
+              f"\n"
+              f"%PACKAGE%\n"
+              f"pkgname = {pkgname}\n"
+          )
+
+          Path("aur/.SRCINFO").write_text(srcinfo)
+          print("Generated .SRCINFO:")
+          print(srcinfo)
+          PY
+
+      - name: Set up AUR SSH
+        shell: bash
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          # Secret is stored base64-encoded to survive GitHub's newline stripping
+          printf '%s' "${AUR_SSH_PRIVATE_KEY}" | base64 -d > ~/.ssh/aur_id_ed25519
+          chmod 600 ~/.ssh/aur_id_ed25519
+          ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts
+          {
+            echo "Host aur.archlinux.org"
+            echo "  IdentityFile ~/.ssh/aur_id_ed25519"
+            echo "  User aur"
+          } >> ~/.ssh/config
+
+      - name: Push to AUR
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone ssh://aur@aur.archlinux.org/opencode-kanban.git /tmp/aur-repo
+          cp aur/PKGBUILD /tmp/aur-repo/PKGBUILD
+          cp aur/.SRCINFO /tmp/aur-repo/.SRCINFO
+          cd /tmp/aur-repo
+          git config user.name "qrafty-ai[bot]"
+          git config user.email "github-actions@qrafty.ai"
+          git add PKGBUILD .SRCINFO
+          git diff --staged --stat
+          git commit -m "Update to v${{ steps.version.outputs.version }}" || echo "Nothing to commit"
+          git push

--- a/README.md
+++ b/README.md
@@ -107,7 +107,13 @@ Only stable `vX.Y.Z` tags are supported (no alpha/pre-release variants).
 3. Add the **private key** as a GitHub Actions secret named `AUR_SSH_PRIVATE_KEY`:
    - Repository → Settings → Secrets and variables → Actions → New repository secret
    - Name: `AUR_SSH_PRIVATE_KEY`
-   - Value: contents of `aur_deploy` (the private key file)
+   - Value: **base64-encoded** private key — GitHub strips trailing newlines from secrets which corrupts PEM files; base64 avoids this:
+
+   ```bash
+   cat aur_deploy | base64 -w0
+   ```
+
+   Paste the single-line output as the secret value.
 
 4. Claim or create the `opencode-kanban` package on AUR (first publish does this automatically if the package doesn't exist yet).
 


### PR DESCRIPTION
## Problem

`aur@aur.archlinux.org: Permission denied (publickey)` — GitHub strips trailing newlines from secret values, which corrupts the PEM private key before it reaches the SSH agent.

## Fix

- **Store the secret base64-encoded** (`cat aur_deploy | base64 -w0`) and decode it in CI with `printf '%s' "$SECRET" | base64 -d`, which restores the exact bytes including the required trailing newline.
- **Drop `KSXGitHub/github-actions-deploy-aur`** in favour of a self-contained pipeline:
  - SSH config written explicitly (`~/.ssh/config` + `ssh-keyscan` for `known_hosts`)
  - `.SRCINFO` generated via an inline Python script (no Arch Linux toolchain needed)
  - AUR repo cloned, files copied, committed and pushed directly

## Secret re-enrollment required

Delete the existing `AUR_SSH_PRIVATE_KEY` secret and re-add the base64 value:

```bash
cat aur_deploy | base64 -w0
# paste the output as the new secret value
```