### PR TITLE
fix(aur): add missing makedepends and fix native linker

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -6,8 +6,8 @@ pkgdesc="Terminal kanban board for managing OpenCode tmux sessions and Git workt
 arch=('x86_64' 'aarch64')
 url="https://github.com/qrafty-ai/opencode-kanban"
 license=('MIT')
-depends=('tmux')
-makedepends=('rust' 'cargo')
+depends=('tmux' 'sqlite')
+makedepends=('rust' 'cargo' 'cmake' 'nasm' 'perl' 'sqlite')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/qrafty-ai/$pkgname/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 
@@ -21,12 +21,16 @@ build() {
     cd "$pkgname-$pkgver"
     export RUSTUP_TOOLCHAIN=stable
     export CARGO_TARGET_DIR=target
-    cargo build --frozen --release --all-features
+    export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc
+    export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+    cargo build --frozen --release
 }
 
 check() {
     cd "$pkgname-$pkgver"
     export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc
+    export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
     cargo test --frozen --lib 2>/dev/null || true
 }
 


### PR DESCRIPTION
## Three root causes for `makepkg` link failures

### 1. `aws-lc-sys` missing build deps
`reqwest` → `rustls` → `aws-lc-rs` → `aws-lc-sys` compiles AWS-LC (a BoringSSL fork) from **C source**. Its build script requires:
- `cmake` ≥ 3.13
- `nasm` (x86_64 assembly optimisations)
- `perl` (code generation scripts)

None were in `makedepends`.

### 2. `libsqlite3-sys` missing sqlite
`sqlx` with the `sqlite` feature links against the system `libsqlite3` via `pkg-config`. `sqlite` was not listed in `makedepends` (build-time headers/pkg-config) or `depends` (runtime shared lib).

### 3. Wrong C linker picked up
When `x86_64-linux-gnu-gcc` (a Debian-style cross-compiler) is installed alongside the native toolchain, cargo selects it for the `x86_64-unknown-linux-gnu` target because it matches the target triple naming convention. That cross-compiler uses a different sysroot and cannot find Arch's system libraries (`libsqlite3`, `libgcc_s`, etc.).

`CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc` pins the native compiler, same pattern applied to aarch64.

Also drops `--all-features` — `Cargo.toml` already declares the correct feature set and `--all-features` can activate opt-in features in transitive deps.