### PR TITLE
fix: use OpenCode session API instead of sqlite3 CLI lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ A Rust terminal kanban board for managing Git worktrees and OpenCode tmux sessio
 - Linux or macOS
 - `tmux` installed and available on `PATH` (required)
 - `opencode` installed and available on `PATH` (recommended for attach/resume workflows)
-- `sqlite3` available on `PATH` (recommended for OpenCode session lookup)
 
 ## Quickstart (2 minutes)
 
@@ -32,7 +31,6 @@ A Rust terminal kanban board for managing Git worktrees and OpenCode tmux sessio
    opencode-kanban --version
    tmux -V
    opencode --version
-   sqlite3 --version
    ```
 
 3. Start the app:
@@ -146,8 +144,6 @@ The app creates config/data files on demand.
   - Install tmux and confirm `tmux -V` works in the same shell.
 - `OpenCode binary not found`:
   - Install OpenCode and confirm `opencode --version` works.
-- OpenCode session lookup issues:
-  - Install `sqlite3` and confirm `sqlite3 --version` works.
 - Mouse scroll/click not working well in tmux:
   - Run `tmux set -g mouse on`.
 


### PR DESCRIPTION
## Summary
- replace `opencode_query_session_by_dir` sqlite CLI query with OpenCode `GET /session?directory=...` API lookup
- add focused unit tests that verify the directory query parameter and empty-result behavior
- remove README instructions that required `sqlite3` on PATH for session lookup

## Verification
- `cargo fmt`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build --release`