### PR TITLE
fix(worktree): default worktree root to home directory

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3563,7 +3563,7 @@ mod tests {
     #[test]
     fn create_task_error_dialog_state_branch_collision_is_concise() {
         let err = anyhow::anyhow!(
-            "worktree creation failed: failed to create worktree `/home/cc/codes/playgrounds/.opencode-kanban-worktrees/test/c-2` for branch `c` from `main`: git command failed in /home/cc/codes/playgrounds/test: git worktree add -b c /home/cc/codes/playgrounds/.opencode-kanban-worktrees/test/c-2 main\nstdout:\nstderr: Preparing worktree (new branch 'c')\nfatal: a branch named 'c' already exists"
+            "worktree creation failed: failed to create worktree `/home/cc/.opencode-kanban-worktrees/test/c-2` for branch `c` from `main`: git command failed in /home/cc/codes/playgrounds/test: git worktree add -b c /home/cc/.opencode-kanban-worktrees/test/c-2 main\nstdout:\nstderr: Preparing worktree (new branch 'c')\nfatal: a branch named 'c' already exists"
         );
 
         let dialog = create_task_error_dialog_state(&err);

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -198,9 +198,12 @@ where
 
 /// Get worktrees root directory for a repo
 pub fn worktrees_root_for_repo(repo_path: &Path) -> PathBuf {
-    let parent = repo_path
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
-    parent.join(".opencode-kanban-worktrees")
+    dirs::home_dir()
+        .unwrap_or_else(|| {
+            repo_path
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from("."))
+        })
+        .join(".opencode-kanban-worktrees")
 }


### PR DESCRIPTION
## Summary
- Change default worktree root from repo-local parent directories to the user's home directory at `~/.opencode-kanban-worktrees`.
- Keep a safe fallback to the previous parent-based behavior only when the home directory cannot be resolved.
- Update the related test fixture string to reflect the new default worktree path shape.