### PR TITLE
fix(opencode): launch server from user home directory

### DIFF
--- a/src/opencode/server.rs
+++ b/src/opencode/server.rs
@@ -204,24 +204,28 @@ fn is_healthy_response(response: &str) -> bool {
 fn spawn_opencode_server(binary: &str, config: &ServerConfig) -> Result<(), String> {
     let port = config.port.to_string();
 
-    Command::new(binary)
-        .args([
-            "serve",
-            "--port",
-            port.as_str(),
-            "--hostname",
-            config.hostname.as_str(),
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .map(|_| ())
-        .map_err(|err| {
-            format!(
-                "failed to launch `{binary} serve --port {} --hostname {}`: {err}",
-                config.port, config.hostname
-            )
-        })
+    let mut cmd = Command::new(binary);
+    if let Some(home_dir) = dirs::home_dir() {
+        cmd.current_dir(home_dir);
+    }
+
+    cmd.args([
+        "serve",
+        "--port",
+        port.as_str(),
+        "--hostname",
+        config.hostname.as_str(),
+    ])
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .spawn()
+    .map(|_| ())
+    .map_err(|err| {
+        format!(
+            "failed to launch `{binary} serve --port {} --hostname {}`: {err}",
+            config.port, config.hostname
+        )
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Set the OpenCode server spawn command to use the user's home directory as its working directory when available.
- Keep existing behavior unchanged when a home directory cannot be resolved by skipping explicit `current_dir` in that edge case.
- Prevent `opencode serve` from inheriting an unintended `/` working directory in ULW launch contexts.

## Verification
- `lsp_diagnostics` on `src/opencode/server.rs` reports no diagnostics.
- `cargo test --lib` passes.
- `cargo build` passes.