### PR TITLE
feat(ui): add project cycling shortcuts and project name header

### DIFF
--- a/src/app/input/key.rs
+++ b/src/app/input/key.rs
@@ -78,6 +78,16 @@ impl App {
                 KeyAction::OpenArchiveView => {
                     self.update(Message::OpenArchiveView)?;
                 }
+                KeyAction::ProjectNext => {
+                    if self.current_view == View::Board {
+                        self.update(Message::SwitchToNextProject)?;
+                    }
+                }
+                KeyAction::ProjectPrev => {
+                    if self.current_view == View::Board {
+                        self.update(Message::SwitchToPrevProject)?;
+                    }
+                }
                 _ => {}
             }
             return Ok(());

--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -76,6 +76,8 @@ pub enum Message {
     CycleTodoVisualization,
     SwitchToProjectList,
     SwitchToBoard(PathBuf),
+    SwitchToNextProject,
+    SwitchToPrevProject,
     ProjectListSelectUp,
     ProjectListSelectDown,
     ProjectListConfirm,

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -484,6 +484,42 @@ impl App {
                 self.archived_tasks.clear();
                 self.archive_selected_index = 0;
             }
+            Message::SwitchToNextProject => {
+                if self.current_view == View::Board {
+                    let len = self.project_list.len();
+                    if len > 0 {
+                        let idx = (self.selected_project_index + 1) % len;
+                        if let Some(project) = self.project_list.get(idx) {
+                            self.selected_project_index = idx;
+                            self.project_list_state.select(Some(idx));
+                            self.project_detail_cache = load_project_detail(project);
+                            self.switch_project(project.path.clone())?;
+                            self.archived_tasks.clear();
+                            self.archive_selected_index = 0;
+                        }
+                    }
+                }
+            }
+            Message::SwitchToPrevProject => {
+                if self.current_view == View::Board {
+                    let len = self.project_list.len();
+                    if len > 0 {
+                        let idx = if self.selected_project_index == 0 {
+                            len - 1
+                        } else {
+                            self.selected_project_index - 1
+                        };
+                        if let Some(project) = self.project_list.get(idx) {
+                            self.selected_project_index = idx;
+                            self.project_list_state.select(Some(idx));
+                            self.project_detail_cache = load_project_detail(project);
+                            self.switch_project(project.path.clone())?;
+                            self.archived_tasks.clear();
+                            self.archive_selected_index = 0;
+                        }
+                    }
+                }
+            }
             Message::ProjectListSelectUp => {
                 if self.selected_project_index > 0 {
                     self.selected_project_index -= 1;

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -23,6 +23,8 @@ pub enum KeyAction {
     OpenArchiveView,
     ShrinkPanel,
     ExpandPanel,
+    ProjectNext,
+    ProjectPrev,
     ProjectUp,
     ProjectDown,
     ProjectConfirm,
@@ -194,6 +196,18 @@ const GLOBAL_DEFS: &[ActionDef] = &[
         action: KeyAction::ExpandPanel,
         description: "widen side panel",
         defaults: &[">"],
+    },
+    ActionDef {
+        id: "project_next",
+        action: KeyAction::ProjectNext,
+        description: "switch to next project",
+        defaults: &["N"],
+    },
+    ActionDef {
+        id: "project_prev",
+        action: KeyAction::ProjectPrev,
+        description: "switch to previous project",
+        defaults: &["P"],
     },
 ];
 
@@ -467,6 +481,13 @@ impl Keybindings {
             format!(
                 "  {}: toggle detail/kanban view",
                 self.display_for(KeyContext::Global, KeyAction::ToggleView)
+                    .unwrap_or_else(|| "-".to_string())
+            ),
+            format!(
+                "  {} / {}: switch next/previous project",
+                self.display_for(KeyContext::Global, KeyAction::ProjectNext)
+                    .unwrap_or_else(|| "-".to_string()),
+                self.display_for(KeyContext::Global, KeyAction::ProjectPrev)
                     .unwrap_or_else(|| "-".to_string())
             ),
             String::new(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -362,11 +362,9 @@ fn render_header(frame: &mut Frame<'_>, area: Rect, app: &App) {
         .constraints([Constraint::Percentage(65), Constraint::Percentage(35)])
         .split(area);
 
-    let title = if app.category_edit_mode {
-        "opencode-kanban [CATEGORY EDIT]"
-    } else {
-        "opencode-kanban"
-    };
+    let project_name =
+        resolve_header_project_name(app.current_project_path.as_deref(), &app.project_list);
+    let title = header_title(&project_name, app.category_edit_mode);
 
     let mut left = Label::default()
         .text(title)
@@ -385,6 +383,34 @@ fn render_header(frame: &mut Frame<'_>, area: Rect, app: &App) {
         .foreground(theme.base.text_muted)
         .background(theme.base.surface);
     right.view(frame, sections[1]);
+}
+
+fn header_title(project_name: &str, category_edit_mode: bool) -> String {
+    if category_edit_mode {
+        format!("opencode-kanban [{project_name}] [CATEGORY EDIT]")
+    } else {
+        format!("opencode-kanban [{project_name}]")
+    }
+}
+
+fn resolve_header_project_name(
+    current_project_path: Option<&std::path::Path>,
+    project_list: &[crate::projects::ProjectInfo],
+) -> String {
+    if let Some(path) = current_project_path {
+        if let Some(project) = project_list
+            .iter()
+            .find(|project| project.path.as_path() == path)
+        {
+            return project.name.clone();
+        }
+
+        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+            return stem.to_string();
+        }
+    }
+
+    crate::projects::DEFAULT_PROJECT.to_string()
 }
 
 fn render_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
@@ -4248,6 +4274,7 @@ fn render_settings_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::projects::ProjectInfo;
     use crate::types::SessionTodoItem;
     use uuid::Uuid;
 
@@ -4275,6 +4302,43 @@ mod tests {
     fn test_command_palette_hides_results_on_short_terminal() {
         assert!(!should_render_command_palette_results((120, 9)));
         assert!(should_render_command_palette_results((120, 10)));
+    }
+
+    #[test]
+    fn test_header_title_includes_project_name() {
+        assert_eq!(
+            header_title("client-api", false),
+            "opencode-kanban [client-api]"
+        );
+        assert_eq!(
+            header_title("client-api", true),
+            "opencode-kanban [client-api] [CATEGORY EDIT]"
+        );
+    }
+
+    #[test]
+    fn test_resolve_header_project_name_prefers_project_list_name() {
+        let path = std::path::PathBuf::from("/tmp/dbs/opencode-kanban.sqlite");
+        let projects = vec![ProjectInfo {
+            name: "workspace-main".to_string(),
+            path: path.clone(),
+        }];
+
+        assert_eq!(
+            resolve_header_project_name(Some(path.as_path()), &projects),
+            "workspace-main"
+        );
+    }
+
+    #[test]
+    fn test_resolve_header_project_name_falls_back_to_path_stem() {
+        let path = std::path::PathBuf::from("/tmp/dbs/solo.sqlite");
+        let projects = Vec::new();
+
+        assert_eq!(
+            resolve_header_project_name(Some(path.as_path()), &projects),
+            "solo"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add global `Shift+N` / `Shift+P` shortcuts to switch to next/previous project from board and detail view paths
- implement wrap-around project switching in app update flow and include keybinding help text updates
- add header project name rendering (`opencode-kanban [project]`) plus unit tests for switching behavior and header naming

## Verification
- `cargo test --lib`
- `cargo test --lib shift_`
- `cargo test --lib resolve_header_project_name`