### PR TITLE
feat(task): add task editing and project list reordering

### DIFF
--- a/src/app/input/key.rs
+++ b/src/app/input/key.rs
@@ -135,6 +135,8 @@ impl App {
                 match action {
                     KeyAction::ProjectUp => self.update(Message::ProjectListSelectUp)?,
                     KeyAction::ProjectDown => self.update(Message::ProjectListSelectDown)?,
+                    KeyAction::ProjectMoveUp => self.update(Message::ProjectListMoveUp)?,
+                    KeyAction::ProjectMoveDown => self.update(Message::ProjectListMoveDown)?,
                     KeyAction::ProjectConfirm => self.update(Message::ProjectListConfirm)?,
                     KeyAction::NewProject => self.update(Message::OpenNewProjectDialog)?,
                     KeyAction::ProjectRename => self.update(Message::OpenRenameProjectDialog)?,
@@ -282,6 +284,9 @@ impl App {
                 }
                 KeyAction::DeleteTask => {
                     self.update(Message::OpenDeleteTaskDialog)?;
+                }
+                KeyAction::EditTask => {
+                    self.update(Message::OpenEditTaskDialog)?;
                 }
                 KeyAction::ArchiveTask => {
                     self.update(Message::OpenArchiveTaskDialog)?;

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -61,6 +61,7 @@ impl App {
                                 task_column: col,
                                 items: vec![
                                     ContextMenuItem::Attach,
+                                    ContextMenuItem::Edit,
                                     ContextMenuItem::Delete,
                                     ContextMenuItem::Move,
                                 ],

--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use crossterm::event::{KeyEvent, MouseEvent};
 
 use super::state::{
-    CategoryInputField, DeleteTaskField, DetailFocus, NewProjectField, NewTaskField,
+    CategoryInputField, DeleteTaskField, DetailFocus, EditTaskField, NewProjectField, NewTaskField,
     RenameProjectField, RenameRepoField, SettingsSection,
 };
 
@@ -48,6 +48,7 @@ pub enum Message {
     OpenRenameCategoryDialog,
     OpenDeleteCategoryDialog,
     OpenDeleteTaskDialog,
+    OpenEditTaskDialog,
     OpenArchiveTaskDialog,
     SubmitCategoryInput,
     ConfirmDeleteCategory,
@@ -60,6 +61,7 @@ pub enum Message {
     DeleteTaskToggleRemoveWorktree,
     DeleteTaskToggleDeleteBranch,
     ConfirmDeleteTask,
+    ConfirmEditTask,
     ConfirmArchiveTask,
     UnarchiveTask,
     ArchiveSelectUp,
@@ -98,9 +100,12 @@ pub enum Message {
     FocusCategoryInputField(CategoryInputField),
     FocusNewProjectField(NewProjectField),
     FocusDeleteTaskField(DeleteTaskField),
+    FocusEditTaskField(EditTaskField),
     ToggleDeleteTaskCheckbox(DeleteTaskField),
     FocusDialogButton(String),
     SelectProject(usize),
     SelectCommandPaletteItem(usize),
     ToggleCategoryEditMode,
+    ProjectListMoveUp,
+    ProjectListMoveDown,
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -142,6 +142,22 @@ pub enum DeleteTaskField {
     Cancel,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum EditTaskField {
+    Title,
+    Save,
+    Cancel,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct EditTaskDialogState {
+    pub task_id: Uuid,
+    pub repo_path: String,
+    pub branch: String,
+    pub title_input: String,
+    pub focused_field: EditTaskField,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DeleteTaskDialogState {
     pub task_id: Uuid,
@@ -299,6 +315,7 @@ pub struct RepoUnavailableDialogState {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ContextMenuItem {
     Attach,
+    Edit,
     Delete,
     Move,
 }
@@ -367,6 +384,7 @@ pub enum ActiveDialog {
     Error(ErrorDialogState),
     ArchiveTask(ArchiveTaskDialogState),
     DeleteTask(DeleteTaskDialogState),
+    EditTask(EditTaskDialogState),
     MoveTask(MoveTaskDialogState),
     WorktreeNotFound(WorktreeNotFoundDialogState),
     RepoUnavailable(RepoUnavailableDialogState),

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -410,6 +410,7 @@ impl App {
             }
             Message::OpenDeleteCategoryDialog => self.open_delete_category_dialog()?,
             Message::OpenDeleteTaskDialog => self.open_delete_task_dialog()?,
+            Message::OpenEditTaskDialog => self.open_edit_task_dialog()?,
             Message::OpenArchiveTaskDialog => self.open_archive_task_dialog()?,
             Message::SubmitCategoryInput => self.confirm_category_input()?,
             Message::ConfirmDeleteCategory => self.confirm_delete_category()?,
@@ -464,6 +465,7 @@ impl App {
             | Message::DeleteTaskToggleRemoveWorktree
             | Message::DeleteTaskToggleDeleteBranch => {}
             Message::ConfirmDeleteTask => self.confirm_delete_task()?,
+            Message::ConfirmEditTask => self.confirm_edit_task()?,
             Message::ConfirmArchiveTask => self.confirm_archive_task()?,
             Message::UnarchiveTask => self.unarchive_selected_task()?,
             Message::ArchiveSelectUp => {
@@ -502,6 +504,36 @@ impl App {
                     if let Some(project) = self.project_list.get(self.selected_project_index) {
                         self.project_detail_cache = load_project_detail(project);
                     }
+                }
+            }
+            Message::ProjectListMoveUp => {
+                if self.selected_project_index > 0
+                    && self.selected_project_index < self.project_list.len()
+                {
+                    let from = self.selected_project_index;
+                    let to = from - 1;
+                    self.project_list.swap(from, to);
+                    self.selected_project_index = to;
+                    self.project_list_state
+                        .select(Some(self.selected_project_index));
+                    if let Some(project) = self.project_list.get(self.selected_project_index) {
+                        self.project_detail_cache = load_project_detail(project);
+                    }
+                    self.persist_project_order_with_notice();
+                }
+            }
+            Message::ProjectListMoveDown => {
+                if self.selected_project_index + 1 < self.project_list.len() {
+                    let from = self.selected_project_index;
+                    let to = from + 1;
+                    self.project_list.swap(from, to);
+                    self.selected_project_index = to;
+                    self.project_list_state
+                        .select(Some(self.selected_project_index));
+                    if let Some(project) = self.project_list.get(self.selected_project_index) {
+                        self.project_detail_cache = load_project_detail(project);
+                    }
+                    self.persist_project_order_with_notice();
                 }
             }
             Message::ProjectListConfirm => {
@@ -734,6 +766,11 @@ impl App {
                     if field != DeleteTaskField::Delete {
                         state.confirm_destructive = false;
                     }
+                }
+            }
+            Message::FocusEditTaskField(field) => {
+                if let ActiveDialog::EditTask(state) = &mut self.active_dialog {
+                    state.focused_field = field;
                 }
             }
             Message::ToggleDeleteTaskCheckbox(field) => {

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -166,6 +166,12 @@ pub fn all_commands() -> Vec<CommandDef> {
             message: Some(Message::OpenNewTaskDialog),
         },
         CommandDef {
+            id: "edit_task",
+            display_name: "Edit Selected Task",
+            keybinding: "e",
+            message: Some(Message::OpenEditTaskDialog),
+        },
+        CommandDef {
             id: "archive_task",
             display_name: "Archive Selected Task",
             keybinding: "a",
@@ -329,8 +335,8 @@ mod tests {
         let commands = all_commands();
         assert_eq!(
             commands.len(),
-            23,
-            "Expected 23 commands, found {}",
+            24,
+            "Expected 24 commands, found {}",
             commands.len()
         );
     }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -25,6 +25,8 @@ pub enum KeyAction {
     ExpandPanel,
     ProjectUp,
     ProjectDown,
+    ProjectMoveUp,
+    ProjectMoveDown,
     ProjectConfirm,
     NewProject,
     ProjectRename,
@@ -42,6 +44,7 @@ pub enum KeyAction {
     RenameCategory,
     DeleteCategory,
     DeleteTask,
+    EditTask,
     ArchiveTask,
     MoveTaskLeft,
     MoveTaskRight,
@@ -211,6 +214,18 @@ const PROJECT_LIST_DEFS: &[ActionDef] = &[
         defaults: &["j", "Down"],
     },
     ActionDef {
+        id: "move_up",
+        action: KeyAction::ProjectMoveUp,
+        description: "move project up",
+        defaults: &["K"],
+    },
+    ActionDef {
+        id: "move_down",
+        action: KeyAction::ProjectMoveDown,
+        description: "move project down",
+        defaults: &["J"],
+    },
+    ActionDef {
         id: "confirm",
         action: KeyAction::ProjectConfirm,
         description: "open project",
@@ -322,6 +337,12 @@ const BOARD_DEFS: &[ActionDef] = &[
         defaults: &["d"],
     },
     ActionDef {
+        id: "edit_task",
+        action: KeyAction::EditTask,
+        description: "edit selected task",
+        defaults: &["e"],
+    },
+    ActionDef {
         id: "archive_task",
         action: KeyAction::ArchiveTask,
         description: "archive selected task",
@@ -405,6 +426,7 @@ impl Keybindings {
             "switch_project" => self.display_for(KeyContext::Global, KeyAction::OpenPalette),
             "toggle_view" => self.display_for(KeyContext::Global, KeyAction::ToggleView),
             "new_task" => self.display_for(KeyContext::Board, KeyAction::NewTask),
+            "edit_task" => self.display_for(KeyContext::Board, KeyAction::EditTask),
             "open_archive_view" => self.display_for(KeyContext::Global, KeyAction::OpenArchiveView),
             "archive_task" => self.display_for(KeyContext::Board, KeyAction::ArchiveTask),
             "attach_task" => self.display_for(KeyContext::Board, KeyAction::AttachTask),
@@ -479,6 +501,13 @@ impl Keybindings {
             format!(
                 "  {}: select next project",
                 self.display_for(KeyContext::ProjectList, KeyAction::ProjectDown)
+                    .unwrap_or_else(|| "-".to_string())
+            ),
+            format!(
+                "  {} / {}: reorder project up/down",
+                self.display_for(KeyContext::ProjectList, KeyAction::ProjectMoveUp)
+                    .unwrap_or_else(|| "-".to_string()),
+                self.display_for(KeyContext::ProjectList, KeyAction::ProjectMoveDown)
                     .unwrap_or_else(|| "-".to_string())
             ),
             format!(
@@ -571,6 +600,11 @@ impl Keybindings {
             format!(
                 "  {}: delete task",
                 self.display_for(KeyContext::Board, KeyAction::DeleteTask)
+                    .unwrap_or_else(|| "-".to_string())
+            ),
+            format!(
+                "  {}: edit selected task",
+                self.display_for(KeyContext::Board, KeyAction::EditTask)
                     .unwrap_or_else(|| "-".to_string())
             ),
             format!(
@@ -946,5 +980,32 @@ mod tests {
             KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
         );
         assert_eq!(action, Some(KeyAction::SelectBottom));
+    }
+
+    #[test]
+    fn defaults_include_project_reorder_j_and_k_with_shift() {
+        let keys = Keybindings::load();
+
+        let move_up = keys.action_for_key(
+            KeyContext::ProjectList,
+            KeyEvent::new(KeyCode::Char('K'), KeyModifiers::SHIFT),
+        );
+        assert_eq!(move_up, Some(KeyAction::ProjectMoveUp));
+
+        let move_down = keys.action_for_key(
+            KeyContext::ProjectList,
+            KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT),
+        );
+        assert_eq!(move_down, Some(KeyAction::ProjectMoveDown));
+    }
+
+    #[test]
+    fn defaults_include_edit_task() {
+        let keys = Keybindings::load();
+        let action = keys.action_for_key(
+            KeyContext::Board,
+            KeyEvent::new(KeyCode::Char('e'), KeyModifiers::empty()),
+        );
+        assert_eq!(action, Some(KeyAction::EditTask));
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -32,6 +32,7 @@ pub struct Settings {
     pub poll_interval_ms: u64,
     pub side_panel_width: u16,
     pub scroll_column_width_chars: u16,
+    pub project_order: Vec<String>,
     pub keybindings: KeybindingsConfig,
 }
 
@@ -53,6 +54,7 @@ impl Default for Settings {
             poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
             side_panel_width: DEFAULT_SIDE_PANEL_WIDTH,
             scroll_column_width_chars: DEFAULT_SCROLL_COLUMN_WIDTH_CHARS,
+            project_order: Vec::new(),
             keybindings: KeybindingsConfig::default(),
         }
     }
@@ -312,6 +314,7 @@ mod tests {
             settings.scroll_column_width_chars,
             DEFAULT_SCROLL_COLUMN_WIDTH_CHARS
         );
+        assert!(settings.project_order.is_empty());
         assert_eq!(settings.keybindings, KeybindingsConfig::default());
         assert_eq!(settings.custom_theme, CustomThemeConfig::default());
     }
@@ -328,6 +331,7 @@ mod tests {
             poll_interval_ms: 2_500,
             side_panel_width: 55,
             scroll_column_width_chars: 48,
+            project_order: vec!["/tmp/demo.sqlite".to_string()],
             keybindings: KeybindingsConfig::default(),
         };
         expected.validate();
@@ -350,6 +354,7 @@ mod tests {
             poll_interval_ms: 1,
             side_panel_width: 999,
             scroll_column_width_chars: 999,
+            project_order: Vec::new(),
             keybindings: KeybindingsConfig::default(),
         };
 


### PR DESCRIPTION
## Summary
- Add title-only task editing flow with a dedicated Edit Task dialog, keybinding (`e`), command palette command, and context-menu action.
- Add Project List reordering with `J/K`, persist the custom order in settings, and apply persisted ordering on refresh.
- Extend DB/update plumbing, keybindings/help/footer text, and tests for edit flow, reorder behavior, and persistence.

## Validation
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build --release`