### PR TITLE
feat: add 'w' keybinding to open task in OpenCode web UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,16 +1745,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "opencode-kanban"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "clap",
  "crossterm 0.28.1",
  "dirs",
  "notify-rust",
  "nucleo",
+ "open",
  "regex",
  "reqwest",
  "serde",
@@ -1810,6 +1842,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ termlauncher = "0.2"
 notify-rust = "4"
 uuid = { version = "1", features = ["v4", "serde"] }
 urlencoding = "2"
+open = "5"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/app/input/key.rs
+++ b/src/app/input/key.rs
@@ -335,6 +335,9 @@ impl App {
                 KeyAction::OpenInNewTerminal => {
                     self.update(Message::OpenSelectedTaskInNewTerminal)?;
                 }
+                KeyAction::OpenInWeb => {
+                    self.update(Message::OpenSelectedTaskInWeb)?;
+                }
                 KeyAction::CycleTodoVisualization => {
                     self.update(Message::CycleTodoVisualization)?;
                 }

--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -22,6 +22,7 @@ pub enum Message {
     SelectDown,
     AttachSelectedTask,
     OpenSelectedTaskInNewTerminal,
+    OpenSelectedTaskInWeb,
     OpenNewTaskDialog,
     OpenCommandPalette,
     OpenTaskPalette,

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -63,6 +63,15 @@ impl App {
             }
             Message::AttachSelectedTask => self.attach_selected_task()?,
             Message::OpenSelectedTaskInNewTerminal => self.open_selected_task_in_new_terminal()?,
+            Message::OpenSelectedTaskInWeb => {
+                if let Some(task) = self.selected_task()
+                    && let (Some(session_id), Some(worktree_path)) =
+                        (&task.opencode_session_id, &task.worktree_path)
+                    && let Err(e) = crate::opencode::opencode_open_in_web(session_id, worktree_path)
+                {
+                    tracing::error!("Failed to open session in browser: {}", e);
+                }
+            }
             Message::OpenNewTaskDialog => {
                 let usage = repo_selection_usage_map(&self.db);
                 let ranked_repo_indexes = rank_repos_for_query("", &self.repos, &usage);

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -54,6 +54,7 @@ pub enum KeyAction {
     MoveTaskUp,
     AttachTask,
     OpenInNewTerminal,
+    OpenInWeb,
     CycleTodoVisualization,
     Dismiss,
     ToggleCategoryEditMode,
@@ -400,6 +401,12 @@ const BOARD_DEFS: &[ActionDef] = &[
         defaults: &["o"],
     },
     ActionDef {
+        id: "open_in_web",
+        action: KeyAction::OpenInWeb,
+        description: "open selected task in web browser",
+        defaults: &["w"],
+    },
+    ActionDef {
         id: "cycle_todo_visualization",
         action: KeyAction::CycleTodoVisualization,
         description: "cycle todo visualization",
@@ -454,6 +461,7 @@ impl Keybindings {
             "open_in_new_terminal" => {
                 self.display_for(KeyContext::Board, KeyAction::OpenInNewTerminal)
             }
+            "open_in_web" => self.display_for(KeyContext::Board, KeyAction::OpenInWeb),
             "add_category" => self.display_for(KeyContext::Board, KeyAction::AddCategory),
             "rename_category" => self.display_for(KeyContext::Board, KeyAction::RenameCategory),
             "delete_category" => self.display_for(KeyContext::Board, KeyAction::DeleteCategory),
@@ -605,6 +613,11 @@ impl Keybindings {
             format!(
                 "  {}: open selected task in new terminal",
                 self.display_for(KeyContext::Board, KeyAction::OpenInNewTerminal)
+                    .unwrap_or_else(|| "-".to_string())
+            ),
+            format!(
+                "  {}: open selected task in web browser",
+                self.display_for(KeyContext::Board, KeyAction::OpenInWeb)
                     .unwrap_or_else(|| "-".to_string())
             ),
             format!(

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1069,3 +1069,13 @@ mod tests {
         assert_eq!(action, Some(KeyAction::OpenInNewTerminal));
     }
 }
+
+#[test]
+fn defaults_include_open_in_web() {
+    let keys = Keybindings::load();
+    let action = keys.action_for_key(
+        KeyContext::Board,
+        KeyEvent::new(KeyCode::Char('w'), KeyModifiers::empty()),
+    );
+    assert_eq!(action, Some(KeyAction::OpenInWeb));
+}

--- a/src/opencode/mod.rs
+++ b/src/opencode/mod.rs
@@ -726,4 +726,22 @@ mod tests {
             .expect("mock session lookup server thread should join");
         Ok(())
     }
+    #[test]
+    fn test_open_in_web_generates_correct_url() {
+        let session_id = "test-session-123";
+        let worktree_path = "/home/user/projects/my-project";
+
+        // Test URL construction logic
+        let encoded_path =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, worktree_path);
+        let url = format!("{DEFAULT_SERVER_URL}/{encoded_path}/session/{session_id}");
+
+        // Verify the URL contains expected components
+        assert!(url.contains("http://127.0.0.1:4096/"));
+        assert!(url.contains("/session/test-session-123"));
+        assert!(url.contains(&encoded_path));
+
+        // Verify base64 encoding is correct
+        assert_eq!(encoded_path, "L2hvbWUvdXNlci9wcm9qZWN0cy9teS1wcm9qZWN0");
+    }
 }

--- a/src/opencode/mod.rs
+++ b/src/opencode/mod.rs
@@ -212,6 +212,14 @@ pub fn opencode_attach_command(session_id: Option<&str>, worktree_dir: Option<&s
     parts.join(" ")
 }
 
+pub fn opencode_open_in_web(session_id: &str, worktree_path: &str) -> Result<()> {
+    let encoded_path =
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, worktree_path);
+    let url = format!("{DEFAULT_SERVER_URL}/{encoded_path}/session/{session_id}");
+    open::that(&url).with_context(|| format!("failed to open browser for session {session_id}"))?;
+    Ok(())
+}
+
 pub fn opencode_query_session_by_dir(working_dir: &Path) -> Result<Option<String>> {
     #[derive(Debug, Deserialize)]
     struct SessionListEntry {


### PR DESCRIPTION
This PR adds the ability to open a selected task's OpenCode session directly in the web browser using the 'w' keybinding.

## Changes

- **Keyboard shortcut**: Press 'w' on the board to open the selected task in your default browser
- **Web UI URL format**: 
- **Dependencies**: Added 'open' crate for cross-platform browser launching and 'base64' for path encoding

## Files Modified

-  - Added 'open' and 'base64' dependencies
-  - Added OpenInWeb action with 'w' binding
-  - Added OpenSelectedTaskInWeb message
-  - Wired key handler
-  - Added message handler
-  - Added opencode_open_in_web function

## Usage

1. Select a task on the kanban board
2. Press 'w' to open the OpenCode web UI in your default browser
3. The task must have a worktree path and opencode session ID to work