### PR TITLE
Authenticate npm release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -484,6 +484,7 @@ jobs:
         env:
           VERSION: ${{ github.ref_name }}
           NPM_TAG: ${{ steps.npm_tag.outputs.npm_tag }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- Pass `secrets.NPM_TOKEN` as `NODE_AUTH_TOKEN` during npm release publishing.
- Fixes the v0.5.8 publish failure where npm returned `E404`/permission errors despite package artifacts building successfully.

## Verification
- `cargo test --lib --quiet`

## Notes
- `actionlint` is not installed in this workspace, so workflow linting could not be run locally.