### PR TITLE
Update repository metadata after move

### DIFF
--- a/.github/workflows/publish-aur.yaml
+++ b/.github/workflows/publish-aur.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
-          URL="https://github.com/qrafty-ai/opencode-kanban/archive/refs/tags/v${VERSION}.tar.gz"
+          URL="https://github.com/TomCC7/opencode-kanban/archive/refs/tags/v${VERSION}.tar.gz"
           SHA256="$(curl -fsSL "${URL}" | sha256sum | awk '{print $1}')"
           echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
           echo "Tarball URL: ${URL}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ build = "build.rs"
 edition = "2024"
 description = "Terminal kanban board for managing OpenCode tmux sessions"
 license = "MIT"
-repository = "https://github.com/example/opencode-kanban"
+repository = "https://github.com/TomCC7/opencode-kanban"
 
 [package.metadata.wix]
 upgrade-guid = "6F2426D8-489F-4113-8E68-66096E47726E"

--- a/npm/package.json
+++ b/npm/package.json
@@ -16,6 +16,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/qrafty-ai/opencode-kanban.git"
+    "url": "https://github.com/TomCC7/opencode-kanban.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/qrafty-ai/opencode-kanban.git"
+    "url": "https://github.com/TomCC7/opencode-kanban.git"
   },
-  "homepage": "https://github.com/qrafty-ai/opencode-kanban#readme",
+  "homepage": "https://github.com/TomCC7/opencode-kanban#readme",
   "bugs": {
-    "url": "https://github.com/qrafty-ai/opencode-kanban/issues"
+    "url": "https://github.com/TomCC7/opencode-kanban/issues"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Update Cargo and npm package repository metadata to `TomCC7/opencode-kanban`.
- Update the AUR publish workflow source tarball URL to the moved repository.
- Keep the npm package scope as `@qrafty-ai` because that is the existing published package name.

## Verification
- `cargo test --lib --quiet`
- `cargo build`
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- Built npm tarballs with a minimal vendor fixture and confirmed generated package metadata uses `https://github.com/TomCC7/opencode-kanban.git`.