### PR TITLE
ci: label first-time contributors

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -1,0 +1,74 @@
+name: Label first-time contributors
+
+on:
+  pull_request_target:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to evaluate and backfill
+        required: true
+        type: number
+
+# Jobs opt in to only the permissions they need.
+permissions: {}
+
+jobs:
+  label:
+    name: Label first-time contributor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check contribution history and label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        with:
+          script: |
+            const label = 'first-time-contributor';
+            const { owner, repo } = context.repo;
+            const prNumber = Number(process.env.PR_NUMBER);
+
+            if (!Number.isSafeInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid pull request number: ${process.env.PR_NUMBER}`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            const author = pr.user?.login;
+
+            if (!author) {
+              core.setFailed(`Pull request #${prNumber} has no author login`);
+              return;
+            }
+
+            const { data: commits } = await github.rest.repos.listCommits({
+              owner,
+              repo,
+              author,
+              sha: context.payload.repository.default_branch,
+              per_page: 1,
+            });
+            const isFirstTimeContributor = commits.length === 0;
+
+            core.info(
+              `pr=#${prNumber} author=${author} priorCommits=${commits.length} ` +
+              `firstTimeContributor=${isFirstTimeContributor}`,
+            );
+
+            if (!isFirstTimeContributor) {
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: [label],
+            });


### PR DESCRIPTION
Adds a narrowly scoped `pull_request_target` workflow that labels authors with no prior commits on the default branch.

Includes a `workflow_dispatch` input so existing PRs can be safely evaluated and backfilled without closing or reopening them. The workflow does not check out or execute PR-controlled code, uses minimal job permissions, and pins `actions/github-script` to a full commit SHA.

Validation:
- embedded script mock: first-time, established, invalid PR number, and missing author
- YAML parse
- pre-commit YAML and whitespace checks